### PR TITLE
Setup of initial overview page in line with issue2 draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # Mac files ++
 .DS_Store
-/node_modules/
 /frontend/node_modules/
-/dist/
+/frontend/dist/
 
 # From access management repo:
 # Yarn stuff; we're not using PnP/Zero installs

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,19 +13,23 @@ by the following steps using a command line window, such as VSC Terminal, bash w
 
 1. Download the repo using Git
 > git clone git@github.com:Altinn/altinn-authentication-frontend.git
+
 Note this assumes that you use SSH keys, but Git documentation will not
 be given here.
 
 2. Install Corepack (this depends on your computer setup). 
 Check version by
 > corepack -h
+
 Tested version 0.18.0 was sufficient for our use.
 
 3. Activate corepack and install the yarn 3.6.3 version used
 elsewhere in Altinn.
+
 > corepack enable
 
 > corepack prepare yarn@3.6.3 --activate
+
 Should state: Preparing yarn@3.6.3 for immediate activation...
 
 > corepack yarn
@@ -36,13 +40,7 @@ This should install the dependencies listed in package.json
 
 The app should now be running in the Vite webserver,
 and is pseudo-available at http://localhost:5173
-(showing just a blue screen)
+(showing just a blue screen),
 
-and at http://localhost:5173/accessmanagement/ui/overview/
-where a pretty Error Page is available, 
-
-or the reachable URL
-http://localhost:5173/accessmanagement/ui/offered-api-delegations/overview
-where you can see the old Access Management Overview page.
-
-Please enjoy the seagull while we rebuild the app.
+and with the new /authfront/ui BasePath, we now reach the old Overview page via
+http://localhost:5173/authfront/ui/offered-api-delegations/overview

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -39,6 +39,10 @@ and is pseudo-available at http://localhost:5173
 (showing just a blue screen)
 
 and at http://localhost:5173/accessmanagement/ui/overview/
-where a pretty Error Page is available.
+where a pretty Error Page is available, 
+
+or the reachable URL
+http://localhost:5173/accessmanagement/ui/offered-api-delegations/overview
+where you can see the old Access Management Overview page.
 
 Please enjoy the seagull while we rebuild the app.

--- a/frontend/src/components/UserInfoBar/UserInfoBar.tsx
+++ b/frontend/src/components/UserInfoBar/UserInfoBar.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 
 import { ReactComponent as AltinnLogo } from '@/assets/AltinnTextLogo.svg';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { fetchUserInfo, fetchReportee } from '@/rtk/features/userInfo/userInfoSlice';
+// import { fetchUserInfo, fetchReportee } from '@/rtk/features/userInfo/userInfoSlice';
 
 import classes from './UserInfoBar.module.css';
 
@@ -16,12 +16,14 @@ export const UserInfoBar = () => {
   const reporteeLoading = useAppSelector((state) => state.userInfo.reporteeLoading);
   const dispatch = useAppDispatch();
 
+  /*
   useEffect(() => {
     if (userLoading || reporteeLoading) {
       void dispatch(fetchUserInfo());
       void dispatch(fetchReportee());
     }
   }, []);
+  */
 
   return (
     <div>

--- a/frontend/src/components/UserInfoBar/UserInfoBar.tsx
+++ b/frontend/src/components/UserInfoBar/UserInfoBar.tsx
@@ -33,6 +33,7 @@ export const UserInfoBar = () => {
         </div>
         <div className={classes.userInfoContent}>
           <div>
+            <p>User Info MISSING here</p>
             {userInfoName && <h5 className={classes.userInfoText}>{userInfoName}</h5>}
             {reporteeName && <h5 className={classes.userInfoText}>for {reporteeName}</h5>}
           </div>

--- a/frontend/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
+++ b/frontend/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
@@ -194,11 +194,11 @@ export const OverviewPageContent = ({
         {t('api_delegation.api_panel_content')}{' '}
         <a
           className={classes.link}
-          href='https://samarbeid.digdir.no/maskinporten/maskinporten/25'
+          href='https://github.com/Altinn/altinn-authentication-frontend/issues/2'
           target='_blank'
           rel='noreferrer'
         >
-          {t('common.maskinporten')}
+          {'(se Runes issue #2)'}
         </a>
       </Panel>
       <div className={classes.explanatoryContainer}>

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -46,7 +46,9 @@
     "change_rights": "Endre rettigheter"
   },
   "authentication_dummy": {
-    "auth_title": "Systembrukere"
+    "auth_title": "Systembrukere",
+    "auth_overview_text": "Her kan du administrere dine systembrukere.",
+    "auth_new_system_user": "Opprett ny systembruker"
   },
     
   "api_delegation": {
@@ -55,7 +57,7 @@
     "api_accesses": "API-tilganger",
     "delegate_new_api": "Deleger nytt API",
     "delete": "Slett",
-    "delegate_new_org": "Deleger nytt API",
+    "delegate_new_org": "Opprett ny systembruker",
     "save": "Lagre",
     "api_delegations": "Systembrukere",
     "api_delegations_received": "Mottatte tilganger til programmerings\u00adgrensesnitt - API",
@@ -64,7 +66,7 @@
     "api_panel_content": "Her kan du styre tilgang til APIer sikret gjennom",
     "org_nr": "Org.nr.",
     "edit_accesses": "Rediger tilganger",
-    "api_overview_text": "Her finner du oversikt over de API-tilganger din virksomhet har delegert til andre virksomheter.",
+    "api_overview_text": "Her kan du administrere dine systembrukere.",
     "api_received_overview_text": "Her finner du oversikt over de API-tilganger din virksomhet har blitt tildelt av andre virksomheter.",
     "give_access_to_new_api": "Gi tilgang til nytt API",
     "new_org_content_text": "Velg hvilke brukere som skal få tilgang ved å klikke pluss-tegnet. Du kan også legge til ny virksomhet ved å benytte søkefeltet.",

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -45,6 +45,10 @@
     "add_new_employee": "Legg til ny ansatt",
     "change_rights": "Endre rettigheter"
   },
+  "authentication_dummy": {
+    "auth_title": "Systembrukere"
+  },
+    
   "api_delegation": {
     "businesses": "Virksomheter",
     "delegated_apis": "Delegerte API",
@@ -53,7 +57,7 @@
     "delete": "Slett",
     "delegate_new_org": "Deleger nytt API",
     "save": "Lagre",
-    "api_delegations": "Delegerte tilganger til programmerings\u00adgrensesnitt - API",
+    "api_delegations": "Systembrukere",
     "api_delegations_received": "Mottatte tilganger til programmerings\u00adgrensesnitt - API",
     "you_have_delegated_accesses": "Du har tidligere delegert disse tilgangene:",
     "you_have_received_accesses": "Du har mottatt disse tilgangene:",

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -48,7 +48,11 @@
   "authentication_dummy": {
     "auth_title": "Systembrukere",
     "auth_overview_text": "Her kan du administrere dine systembrukere.",
-    "auth_new_system_user": "Opprett ny systembruker"
+    "auth_new_system_user": "Opprett ny systembruker",
+    "auth_card_title": "Du har tidligere opprettet disse systembrukerne",
+    "auth_api_panel_content": "Her skulle vært en liste over systembrukere"
+    
+
   },
     
   "api_delegation": {
@@ -63,7 +67,7 @@
     "api_delegations_received": "Mottatte tilganger til programmerings\u00adgrensesnitt - API",
     "you_have_delegated_accesses": "Du har tidligere delegert disse tilgangene:",
     "you_have_received_accesses": "Du har mottatt disse tilgangene:",
-    "api_panel_content": "Her kan du styre tilgang til APIer sikret gjennom",
+    "api_panel_content": "Her skulle vært en liste over systembrukere",
     "org_nr": "Org.nr.",
     "edit_accesses": "Rediger tilganger",
     "api_overview_text": "Her kan du administrere dine systembrukere.",
@@ -80,7 +84,7 @@
     "previous":"Forrige",
     "next": "Neste",
     "add_new_business": "Legg til ny virksomhet",
-    "card_title": "Programmerings\u00adgrensesnitt - API",
+    "card_title": "Du har tidligere opprettet disse systembrukerne",
     "confirmation_page_content_top_text": "Du ønsker å gi rettigheter til følgende API:",
     "confirmation_page_content_second_text": "API-tilgangene blir gitt til:",
     "confirmation_page_content_bottom_text": "Tilgangene vil bli gitt og er gyldige til de aktivt slettes eller trekkes tilbake.",

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,7 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { use } from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-import { RefreshToken } from '@/resources/Token/RefreshToken';
+// import { RefreshToken } from '@/resources/Token/RefreshToken'; // temp inactivaiton 19.09.23
 import { Router } from '@/routes/Router/Router';
 
 import { getConfig } from '../config';
@@ -44,6 +44,7 @@ use(LanguageDetector)
         defaultOptions: import.meta.env.DEV ? queryClientDevDefaults : undefined,
       });
 
+      // temp inactivation 19.09.23: <RefreshToken />
       ReactDOM.createRoot(document.getElementById('root')).render(
         // if you ever wonder why the components render twice it's because of React.StrictMode
         // comment it out if it causes trouble: https://react.dev/reference/react/StrictMode
@@ -51,7 +52,7 @@ use(LanguageDetector)
           <Provider store={store}>
             <QueryClientProvider client={queryClient}>
               <LoadLocalizations>
-                <RefreshToken />
+                
                 <RouterProvider router={Router}></RouterProvider>
               </LoadLocalizations>
             </QueryClientProvider>

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -13,6 +13,13 @@ import { ChooseRightsPage } from '@/features/singleRight/delegate/ChooseRightsPa
 
 import { GeneralPath, SingleRightPath, ApiDelegationPath } from '../paths';
 
+// Note: there are just 8 pages: the elaborate and repetitive route tree below
+// maps out URLs such as /Basepath/OfferedApiDelegations/Overview
+// e.g. /accessmanagement/ui
+// + /offered-api-delegations
+// + /overview
+// = /accessmanagement/ui/offered-api-delegations/overview/
+
 export const Router = createBrowserRouter(
   createRoutesFromElements(
     <Route

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -20,6 +20,22 @@ import { GeneralPath, SingleRightPath, ApiDelegationPath } from '../paths';
 // + /overview
 // = /accessmanagement/ui/offered-api-delegations/overview/
 
+// All these 8 pages are available through Router, despite error messages.
+
+// In summary, the 5 paths in OfferedApiDelegations branch are:
+// /accessmanagement/ui/offered-api-delegations/overview/
+// /accessmanagement/ui/offered-api-delegations/choose-org/
+// /accessmanagement/ui/offered-api-delegations/choose-api/
+// /accessmanagement/ui/offered-api-delegations/receipt/
+// /accessmanagement/ui/offered-api-delegations/confirmation/
+
+// ReceivedApiDelegations only has 1 branch: 
+// /accessmanagement/ui/received-api-delegations/overview/
+
+// Finally, SingleRightPath has 2 branches:
+// /accessmanagement/ui/delegate-single-rights/choose-service/
+// /accessmanagement/ui/delegate-single-rights/choose-rights/
+
 export const Router = createBrowserRouter(
   createRoutesFromElements(
     <Route
@@ -30,6 +46,7 @@ export const Router = createBrowserRouter(
         path={ApiDelegationPath.OfferedApiDelegations}
         errorElement={<NotFoundSite />}
       >
+
         <Route
           path={ApiDelegationPath.Overview}
           element={<OfferedOverviewPage />}
@@ -56,6 +73,7 @@ export const Router = createBrowserRouter(
           errorElement={<NotFoundSite />}
         />
       </Route>
+
       <Route
         path={ApiDelegationPath.ReceivedApiDelegations}
         errorElement={<NotFoundSite />}
@@ -66,6 +84,7 @@ export const Router = createBrowserRouter(
           errorElement={<NotFoundSite />}
         />
       </Route>
+
       <Route
         path={SingleRightPath.DelegateSingleRights}
         errorElement={<NotFoundSite />}
@@ -81,6 +100,7 @@ export const Router = createBrowserRouter(
           errorElement={<NotFoundSite />}
         />
       </Route>
+
     </Route>,
   ),
   { basename: GeneralPath.BasePath },

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -36,6 +36,9 @@ import { GeneralPath, SingleRightPath, ApiDelegationPath } from '../paths';
 // /accessmanagement/ui/delegate-single-rights/choose-service/
 // /accessmanagement/ui/delegate-single-rights/choose-rights/
 
+// with the new BasePath = "/authfront/ui" our Overview page will be at:
+// http://localhost:5173/authfront/ui/offered-api-delegations/overview
+
 export const Router = createBrowserRouter(
   createRoutesFromElements(
     <Route

--- a/frontend/src/routes/paths/GeneralPath.tsx
+++ b/frontend/src/routes/paths/GeneralPath.tsx
@@ -1,5 +1,5 @@
 export enum GeneralPath {
-  BasePath = '/accessmanagement/ui',
+  BasePath = '/authfront/ui',
   Profile = 'ui/Profile',
   Altinn2SingleRights = 'ui/AccessManagement/ServicesAvailableForActor',
 }


### PR DESCRIPTION
## Description
Issue #2 has a draft for a simple HelloWorld page. 

An overview page, reachable at http://localhost:5173/authfront/ui/offered-api-delegations/overview
(also see README for /frontend/), is now available. 

Note the list of system-users is not yet available.

## Related Issue(s)
- #2

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

