### PR TITLE
Overview page has now its own independent path

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -46,3 +46,6 @@ and is pseudo-available at http://localhost:5173
 
 and with the new /authfront/ui BasePath, we now reach the old, but edited Overview page via
 http://localhost:5173/authfront/ui/offered-api-delegations/overview
+
+while the new Authentication OverviewPage on new path is here: <br>
+http://localhost:5173/authfront/ui/auth/overview

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -33,6 +33,7 @@ elsewhere in Altinn.
 Should state: Preparing yarn@3.6.3 for immediate activation...
 
 > corepack yarn
+
 This should install the dependencies listed in package.json
 
 4. Run the Vite webserver script in package.json by
@@ -40,7 +41,8 @@ This should install the dependencies listed in package.json
 
 The app should now be running in the Vite webserver,
 and is pseudo-available at http://localhost:5173
-(showing just a blue screen),
+(showing just a blue screen), or http://localhost:5173/authfront/ui/xxx <br>
+(showing an Error Page with a nice seagull).
 
-and with the new /authfront/ui BasePath, we now reach the old Overview page via
+and with the new /authfront/ui BasePath, we now reach the old, but edited Overview page via
 http://localhost:5173/authfront/ui/offered-api-delegations/overview

--- a/frontend/src/features/overviewpage/OverviewPage.tsx
+++ b/frontend/src/features/overviewpage/OverviewPage.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+
+import { Page, PageHeader, PageContent, PageContainer } from '@/components';
+import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
+import { useMediaQuery } from '@/resources/hooks';
+
+import { OverviewPageContent } from './components/OverviewPageContent';
+import { LayoutState } from './components/LayoutState';
+
+export const OverviewPage = () => {
+  const { t } = useTranslation('common');
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  return (
+    <PageContainer>
+      <Page
+        color='dark'
+        size={isSm ? 'small' : 'medium'}
+      >
+        <PageHeader icon={<ApiIcon />}>{t('api_delegation.api_delegations')}</PageHeader>
+        <PageContent>
+          <OverviewPageContent layout={LayoutState.Offered} />
+        </PageContent>
+      </Page>
+    </PageContainer>
+  );
+};

--- a/frontend/src/features/overviewpage/components/LayoutState.tsx
+++ b/frontend/src/features/overviewpage/components/LayoutState.tsx
@@ -1,0 +1,4 @@
+export enum LayoutState {
+  Offered,
+  Received,
+}

--- a/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.module.css
+++ b/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.module.css
@@ -1,0 +1,37 @@
+@media only screen and (max-width: 768px) {
+  .actionBarContent {
+    padding-left: 0.7rem;
+  }
+
+  .orgDelegationActionBarTitle {
+    font-size: 14px;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .actionBarContent {
+    padding-left: 50px;
+  }
+}
+
+.actionBarContent {
+  padding-right: 10px;
+}
+
+.actionBarText__softDelete {
+  text-decoration: line-through;
+  opacity: 70%;
+}
+
+.actionBarSubtitle__softDelete {
+  text-decoration: line-through;
+  opacity: 70%;
+}
+
+.accordionHeaderRightText {
+  margin-right: 15px;
+}
+
+.additionalText {
+  margin-right: 10px;
+}

--- a/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.test.cy.tsx
+++ b/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.test.cy.tsx
@@ -1,0 +1,313 @@
+import { Provider } from 'react-redux';
+import { mount } from 'cypress/react18';
+import * as React from 'react';
+
+import { OrgDelegationActionBar } from '@/features/apiDelegation/components/OverviewPageContent/OrgDelegationActionBar';
+import store from '@/rtk/app/store';
+
+import type { OverviewOrg } from '@/rtk/features/apiDelegation/apiDelegation/overviewOrg/overviewOrgSlice';
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { reduxStore = store, ...mountOptions } = options as any;
+
+  const wrapped = <Provider store={reduxStore}>{component}</Provider>;
+
+  return mount(wrapped, mountOptions);
+});
+
+describe('OrgDelegationActionBar', () => {
+  describe('AccordionHeader', () => {
+    it('should show delegateNewApi-button on render when delegateToOrgCallback is set', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={false}
+          delegateToOrgCallback={() => null}
+        />,
+      );
+      cy.findByRole('button', { name: /api_delegation.delegate_new_api/i }).should('exist');
+    });
+
+    it('should not show delegateNewApi-button on render when delegateToOrgCallback is not set', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={false}
+        />,
+      );
+      cy.findByRole('button', { name: /api_delegation.delegate_new_api/i }).should('not.exist');
+    });
+
+    it('should show delete button when state isEditable=true', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={true}
+        />,
+      );
+      cy.findByRole('button', { name: /delete/i }).should('exist');
+    });
+
+    it('should not show undo button when state is isEditable=false', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={false}
+        />,
+      );
+      cy.findByRole('button', { name: /undo/i }).should('not.exist');
+    });
+
+    it('should show an undo button and display header with line through when all apis are soft deleted', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: true,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: true,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: true,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={true}
+        />,
+      );
+
+      cy.get('button')
+        .contains('Evry')
+        .should('have.css', 'text-decoration', 'line-through solid rgb(30, 43, 60)');
+      cy.findByRole('button', { name: /undo/i }).should('exist');
+    });
+
+    it('should call softDeleteCallback on button click and isEditable=true ', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      const softDeleteAll = () => {
+        cy.stub();
+      };
+
+      const softDeleteAllSpy = cy.spy(softDeleteAll).as('softDeleteAllSpy');
+
+      cy.mount(
+        <OrgDelegationActionBar
+          organization={overviewOrgs}
+          softDeleteAllCallback={softDeleteAllSpy}
+          softRestoreAllCallback={() => null}
+          isEditable={true}
+        />,
+      );
+
+      cy.findByRole('button', { name: /delete/i }).click();
+      cy.get('@softDeleteAllSpy').should('have.been.called');
+    });
+
+    it('should call softRestoreCallback on buttonclick', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: true,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      const softRestoreAll = () => {
+        cy.stub();
+      };
+
+      const softRestoreAllSpy = cy.spy(softRestoreAll).as('softRestoreAllSpy');
+
+      cy.mount(
+        <OrgDelegationActionBar
+          organization={overviewOrgs}
+          softDeleteAllCallback={() => null}
+          softRestoreAllCallback={softRestoreAllSpy}
+          isEditable={true}
+        />,
+      );
+
+      cy.findByRole('button', { name: /undo/i }).click();
+      cy.get('@softRestoreAllSpy').should('have.been.called');
+    });
+
+    it('should call delegateToOrgCallback on buttonclick', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: true,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      const delegateToNewOrg = () => {
+        cy.stub();
+      };
+
+      const delegateToNewOrgSpy = cy.spy(delegateToNewOrg).as('delegateToNewOrgSpy');
+
+      cy.mount(
+        <OrgDelegationActionBar
+          organization={overviewOrgs}
+          softDeleteAllCallback={() => null}
+          softRestoreAllCallback={() => null}
+          delegateToOrgCallback={delegateToNewOrgSpy}
+          isEditable={true}
+        />,
+      );
+
+      cy.findByRole('button', { name: /delegate_new_api/i }).click();
+      cy.get('@delegateToNewOrgSpy').should('have.been.called');
+    });
+  });
+});

--- a/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.tsx
+++ b/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { Button, List } from '@digdir/design-system-react';
+import cn from 'classnames';
+import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+
+import type { OverviewOrg } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
+import { softDelete, softRestore } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
+import { useAppDispatch } from '@/rtk/app/hooks';
+import { ReactComponent as MinusCircle } from '@/assets/MinusCircle.svg';
+import { ReactComponent as Cancel } from '@/assets/Cancel.svg';
+import { ReactComponent as AddCircle } from '@/assets/AddCircle.svg';
+import { DeletableListItem, ActionBar } from '@/components';
+import { useMediaQuery } from '@/resources/hooks';
+
+import classes from './OrgDelegationActionBar.module.css';
+
+export interface OrgDelegationActionBarProps {
+  organization: OverviewOrg;
+  isEditable: boolean;
+  softRestoreAllCallback: () => void;
+  softDeleteAllCallback: () => void;
+  delegateToOrgCallback?: () => void;
+}
+
+export const OrgDelegationActionBar = ({
+  organization,
+  softRestoreAllCallback,
+  softDeleteAllCallback,
+  isEditable = false,
+  delegateToOrgCallback,
+}: OrgDelegationActionBarProps) => {
+  const [open, setOpen] = useState(false);
+  const { t } = useTranslation('common');
+  const numberOfAccesses = organization.apiList.length.toString();
+  const dispatch = useAppDispatch();
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  const handleSoftDeleteAll = () => {
+    softDeleteAllCallback();
+    setOpen(true);
+  };
+
+  const actions = (
+    <>
+      {delegateToOrgCallback && (
+        <Button
+          variant={'quiet'}
+          color={'primary'}
+          icon={<AddCircle />}
+          size={'medium'}
+          onClick={delegateToOrgCallback}
+          aria-label={String(t('api_delegation.delegate_new_api'))}
+        >
+          {t('api_delegation.delegate_new_api')}
+        </Button>
+      )}
+      {isEditable &&
+        (organization.isAllSoftDeleted ? (
+          <Button
+            variant={'quiet'}
+            color={'secondary'}
+            size={'medium'}
+            icon={<Cancel />}
+            onClick={softRestoreAllCallback}
+            aria-label={String(t('common.undo')) + ' ' + organization.orgName}
+          >
+            {!isSm && t('common.undo')}
+          </Button>
+        ) : (
+          <div>
+            <Button
+              variant={'quiet'}
+              color={'danger'}
+              icon={<MinusCircle />}
+              size={'medium'}
+              onClick={handleSoftDeleteAll}
+              aria-label={String(t('api_delegation.delete')) + ' ' + organization.orgName}
+            >
+              {!isSm && t('api_delegation.delete')}
+            </Button>
+          </div>
+        ))}
+    </>
+  );
+
+  const listItems = organization.apiList.map((item, i) => (
+    <DeletableListItem
+      key={i}
+      softDeleteCallback={() => dispatch(softDelete([organization.id, item.id]))}
+      softRestoreCallback={() => dispatch(softRestore([organization.id, item.id]))}
+      item={item}
+      isEditable={isEditable}
+      scopes={item.scopes}
+    ></DeletableListItem>
+  ));
+
+  return (
+    <ActionBar
+      headingLevel={3}
+      onClick={() => {
+        setOpen(!open);
+      }}
+      open={open}
+      color={'neutral'}
+      actions={actions}
+      title={
+        <div
+          className={cn(classes.orgDelegationActionBarTitle, {
+            [classes.actionBarText__softDelete]: organization.isAllSoftDeleted,
+          })}
+        >
+          {organization.orgName}
+        </div>
+      }
+      subtitle={
+        <div
+          className={cn({
+            [classes.actionBarSubtitle__softDelete]: organization.isAllSoftDeleted,
+          })}
+        >
+          {t('api_delegation.org_nr') + ' ' + organization.orgNr}
+        </div>
+      }
+      additionalText={
+        <div
+          className={cn(classes.additionalText, {
+            [classes.actionBarText__softDelete]: organization.isAllSoftDeleted,
+          })}
+        >
+          {!isSm && (
+            <span>
+              {numberOfAccesses} {t('api_delegation.api_accesses')}
+            </span>
+          )}
+        </div>
+      }
+    >
+      <div className={classes.actionBarContent}>
+        <List borderStyle={'solid'}>{listItems}</List>
+      </div>
+    </ActionBar>
+  );
+};

--- a/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/index.ts
+++ b/frontend/src/features/overviewpage/components/OverviewPageContent/OrgDelegationActionBar/index.ts
@@ -1,0 +1,1 @@
+export { OrgDelegationActionBar } from './OrgDelegationActionBar';

--- a/frontend/src/features/overviewpage/components/OverviewPageContent/OverviewPageContent.module.css
+++ b/frontend/src/features/overviewpage/components/OverviewPageContent/OverviewPageContent.module.css
@@ -1,0 +1,107 @@
+@media only screen and (max-width: 768px) {
+  .overviewAccordionsContainer {
+    margin-top: 0rem;
+  }
+
+  .delegateNewButton {
+    margin-bottom: 1.3rem;
+    margin-top: 0rem;
+  }
+
+  .activeDelegationsHeader {
+    margin-top: 0.1rem;
+  }
+
+  .editButton {
+    align-items: center;
+    justify-content: end;
+    margin-bottom: 0.3rem;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .overviewActionBarContainer {
+    margin-top: 3rem;
+  }
+
+  .delegateNewButton {
+    margin-bottom: 3rem;
+  }
+
+  .activeDelegationsHeader {
+    margin-top: 2rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .saveSection {
+    margin-right: 0.5rem;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .editButton {
+    justify-content: flex-end;
+    align-items: center;
+    display: flex;
+    flex: 1;
+  }
+
+  .explanatoryContainer {
+    margin-top: 30px;
+    display: flex;
+  }
+}
+
+.noActiveDelegations {
+  margin-top: 1.5rem;
+}
+
+.spinnerContainer {
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+.saveSection {
+  margin-top: 2rem;
+}
+
+.apiSubheading {
+  display: flex;
+  margin-bottom: 2rem;
+  font-weight: 500;
+}
+
+.pageContentText {
+  margin-top: -2rem;
+  font-weight: 500;
+}
+
+.link {
+  color: black;
+  text-decoration-line: underline;
+  text-decoration-color: #1eadf7;
+  display: inline-block;
+  background: transparent;
+}
+
+.errorPanel {
+  margin-top: 2rem;
+}
+
+.actionBarWrapper {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.testText {
+  margin-right: 40px;
+}
+
+.testContent {
+  margin: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}

--- a/frontend/src/features/overviewpage/components/OverviewPageContent/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/components/OverviewPageContent/OverviewPageContent.tsx
@@ -1,0 +1,251 @@
+import { Panel } from '@altinn/altinn-design-system';
+import { Button, Spinner } from '@digdir/design-system-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import * as React from 'react';
+
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { ReactComponent as Add } from '@/assets/Add.svg';
+import { ReactComponent as Edit } from '@/assets/Edit.svg';
+import { ReactComponent as Error } from '@/assets/Error.svg';
+import { resetDelegationRequests } from '@/rtk/features/apiDelegation/delegationRequest/delegationRequestSlice';
+import { resetDelegableOrgs } from '@/rtk/features/apiDelegation/delegableOrg/delegableOrgSlice';
+import {
+  fetchOverviewOrgsOffered,
+  fetchOverviewOrgsReceived,
+  restoreAllSoftDeletedItems,
+  softDeleteAll,
+  softRestoreAll,
+  deleteOfferedApiDelegation,
+  deleteReceivedApiDelegation,
+  type OverviewOrg,
+  type DeletionRequest,
+} from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
+import { resetDelegableApis } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
+import { useMediaQuery } from '@/resources/hooks';
+import { ApiDelegationPath } from '@/routes/paths';
+import { ErrorPanel } from '@/components';
+
+import { LayoutState } from '../LayoutState';
+
+import { OrgDelegationActionBar } from './OrgDelegationActionBar';
+import classes from './OverviewPageContent.module.css';
+
+export interface OverviewPageContentInterface {
+  layout: LayoutState;
+}
+
+export const OverviewPageContent = ({
+  layout = LayoutState.Offered,
+}: OverviewPageContentInterface) => {
+  const [saveDisabled, setSaveDisabled] = useState(false);
+  const [isEditable, setIsEditable] = useState(false);
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const overviewOrgs = useAppSelector((state) => state.overviewOrg.overviewOrgs);
+  const error = useAppSelector((state) => state.overviewOrg.error);
+  const loading = useAppSelector((state) => state.overviewOrg.loading);
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fetchData: () => any;
+  let overviewText: string;
+  let accessesHeader: string;
+  let noDelegationsInfoText: string;
+
+  useEffect(() => {
+    if (loading) {
+      void fetchData();
+    }
+    handleSaveDisabled();
+    dispatch(resetDelegableApis());
+    dispatch(resetDelegableOrgs());
+    dispatch(resetDelegationRequests());
+  }, [overviewOrgs, error]);
+
+  switch (layout) {
+    case LayoutState.Offered:
+      fetchData = async () => await dispatch(fetchOverviewOrgsOffered());
+      overviewText = t('api_delegation.api_overview_text');
+      accessesHeader = t('api_delegation.you_have_delegated_accesses');
+      noDelegationsInfoText = t('api_delegation.no_offered_delegations');
+      break;
+    case LayoutState.Received:
+      fetchData = async () => await dispatch(fetchOverviewOrgsReceived());
+      overviewText = t('api_delegation.api_received_overview_text');
+      accessesHeader = t('api_delegation.you_have_received_accesses');
+      noDelegationsInfoText = t('api_delegation.no_received_delegations');
+      break;
+  }
+
+  const goToStartDelegation = () => {
+    dispatch(restoreAllSoftDeletedItems());
+    navigate('/' + ApiDelegationPath.OfferedApiDelegations + '/' + ApiDelegationPath.ChooseOrg);
+  };
+
+  const handleSaveDisabled = () => {
+    for (const org of overviewOrgs) {
+      if (org.isAllSoftDeleted) {
+        setSaveDisabled(false);
+        return;
+      }
+      for (const api of org.apiList) {
+        if (api.isSoftDelete) {
+          setSaveDisabled(false);
+          return;
+        }
+      }
+    }
+    setSaveDisabled(true);
+  };
+
+  const handleSetIsEditable = () => {
+    if (isEditable) {
+      dispatch(restoreAllSoftDeletedItems());
+    }
+    setIsEditable(!isEditable);
+  };
+
+  const mapToDeletionRequest = (orgNr: string, apiId: string) => {
+    const deletionRequest: DeletionRequest = {
+      orgNr,
+      apiId,
+    };
+    return deletionRequest;
+  };
+
+  const handleSave = () => {
+    for (const org of overviewOrgs) {
+      for (const item of org.apiList) {
+        if (item.isSoftDelete) {
+          if (layout === LayoutState.Offered) {
+            void dispatch(deleteOfferedApiDelegation(mapToDeletionRequest(org.orgNr, item.id)));
+          } else if (layout === LayoutState.Received) {
+            void dispatch(deleteReceivedApiDelegation(mapToDeletionRequest(org.orgNr, item.id)));
+          }
+        }
+      }
+    }
+    setIsEditable(false);
+  };
+
+  const activeDelegations = () => {
+    if (error.message) {
+      return (
+        <div className={classes.errorPanel}>
+          <ErrorPanel
+            title={t('api_delegation.data_retrieval_failed')}
+            message={error.message}
+            statusCode={error.statusCode}
+          ></ErrorPanel>
+        </div>
+      );
+    } else if (loading) {
+      return (
+        <div className={classes.spinnerContainer}>
+          <Spinner
+            title={String(t('common.loading'))}
+            size='large'
+          />
+        </div>
+      );
+    } else if (overviewOrgs.length < 1) {
+      return <h3 className={classes.noActiveDelegations}>{noDelegationsInfoText}</h3>;
+    }
+    return overviewOrgs.map((org: OverviewOrg) => (
+      <div
+        key={org.id}
+        className={classes.actionBarWrapper}
+      >
+        <OrgDelegationActionBar
+          organization={org}
+          isEditable={isEditable}
+          softDeleteAllCallback={() => dispatch(softDeleteAll(org.id))}
+          softRestoreAllCallback={() => dispatch(softRestoreAll(org.id))}
+          key={org.id}
+        ></OrgDelegationActionBar>
+      </div>
+    ));
+  };
+
+  return (
+    <div className={classes.overviewActionBarContainer}>
+      {!isSm && <h2 className={classes.pageContentText}>{overviewText}</h2>}
+      {layout === LayoutState.Offered && (
+        <div className={classes.delegateNewButton}>
+          <Button
+            variant='outline'
+            onClick={goToStartDelegation}
+            icon={<Add />}
+            fullWidth={isSm}
+            size='medium'
+          >
+            {t('api_delegation.delegate_new_org')}
+          </Button>
+        </div>
+      )}
+      <Panel
+        title={t('api_delegation.card_title')}
+        forceMobileLayout={isSm}
+        showIcon={!isSm}
+      >
+        {t('api_delegation.api_panel_content')}{' '}
+        <a
+          className={classes.link}
+          href='https://github.com/Altinn/altinn-authentication-frontend/issues/2'
+          target='_blank'
+          rel='noreferrer'
+        >
+          {'(se Runes issue #2) XXXX'}
+        </a>
+      </Panel>
+      <div className={classes.explanatoryContainer}>
+        {overviewOrgs.length > 0 && (
+          <>
+            {isSm ? (
+              <h3 className={classes.apiSubheading}>{accessesHeader}</h3>
+            ) : (
+              <h2 className={classes.apiSubheading}>{accessesHeader}</h2>
+            )}
+            <div className={classes.editButton}>
+              {!isEditable ? (
+                <Button
+                  variant='quiet'
+                  icon={<Edit />}
+                  onClick={handleSetIsEditable}
+                  size='small'
+                >
+                  {t('api_delegation.edit_accesses')}
+                </Button>
+              ) : (
+                <Button
+                  variant='quiet'
+                  icon={<Error />}
+                  onClick={handleSetIsEditable}
+                  size='small'
+                >
+                  {t('common.cancel')}
+                </Button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+      <>{activeDelegations()}</>
+      {isEditable && (
+        <div className={classes.saveSection}>
+          <Button
+            disabled={saveDisabled}
+            onClick={handleSave}
+            color='success'
+            fullWidth={isSm}
+          >
+            {t('api_delegation.save')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/overviewpage/components/OverviewPageContent/index.ts
+++ b/frontend/src/features/overviewpage/components/OverviewPageContent/index.ts
@@ -1,0 +1,1 @@
+export { OverviewPageContent } from './OverviewPageContent';

--- a/frontend/src/features/overviewpage/components/SummaryPage/SummaryPage.module.css
+++ b/frontend/src/features/overviewpage/components/SummaryPage/SummaryPage.module.css
@@ -1,0 +1,63 @@
+@media only screen and (max-width: 768px) {
+  .receiptMainButton {
+    width: 100%;
+  }
+
+  .listText {
+    font-size: 20px;
+  }
+
+  .bottomListText {
+    font-size: 20px;
+    margin-top: 2.5rem;
+  }
+
+  .infoText {
+    font-size: 16px;
+  }
+}
+
+.receiptMainButton {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.navButtonContainer {
+  margin-top: 8rem;
+  display: flex;
+  justify-content: end;
+  margin-bottom: 70px;
+}
+
+.previousButton {
+  display: flex;
+  margin-right: 3rem;
+}
+
+.confirmButton {
+  display: flex;
+}
+
+.infoText {
+  margin-top: 20px;
+  font-weight: 400;
+}
+
+.listText {
+  font-weight: 500;
+}
+
+.bottomListText {
+  font-weight: 500;
+  margin-top: 2.5rem;
+}
+
+.restartButton {
+  display: flex;
+  justify-content: center;
+}
+
+.receiptMainButton {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/src/features/overviewpage/components/SummaryPage/SummaryPage.tsx
+++ b/frontend/src/features/overviewpage/components/SummaryPage/SummaryPage.tsx
@@ -1,0 +1,240 @@
+import { Panel, PanelVariant } from '@altinn/altinn-design-system';
+import { List, Button } from '@digdir/design-system-react';
+import type { Key } from 'react';
+import { t } from 'i18next';
+import { useNavigate } from 'react-router-dom';
+import * as React from 'react';
+
+import { useAppDispatch } from '@/rtk/app/hooks';
+import { ReactComponent as OfficeIcon } from '@/assets/Office1.svg';
+import { ReactComponent as SettingsIcon } from '@/assets/Settings.svg';
+import {
+  CompactDeletableListItem,
+  NavigationButtons,
+  Page,
+  PageContent,
+  PageHeader,
+  type PageColor,
+} from '@/components';
+import type { ApiDelegation } from '@/rtk/features/apiDelegation/delegationRequest/delegationRequestSlice';
+import type { DelegableOrg } from '@/rtk/features/apiDelegation/delegableOrg/delegableOrgSlice';
+import { softRemoveOrg } from '@/rtk/features/apiDelegation/delegableOrg/delegableOrgSlice';
+import { softRemoveApi } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
+import type { DelegableApi } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
+import { useMediaQuery } from '@/resources/hooks/useMediaQuery';
+import { ApiDelegationPath } from '@/routes/paths';
+import { setLoading as setOveviewToReload } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
+
+import { ListTextColor } from '../../../../components/CompactDeletableListItem/CompactDeletableListItem';
+
+import classes from './SummaryPage.module.css';
+
+export interface SummaryPageProps {
+  delegableApis?: DelegableApi[];
+  delegableOrgs?: DelegableOrg[];
+  failedDelegations?: ApiDelegation[];
+  successfulDelegations?: ApiDelegation[];
+  restartProcessPath: string;
+  pageHeaderText: string;
+  headerIcon: React.ReactNode;
+  headerColor?: PageColor;
+  topListText?: string;
+  failedDelegationText?: string;
+  bottomListText?: string;
+  bottomText?: string;
+  confirmationButtonClick?: () => void;
+  confirmationButtonDisabled?: boolean;
+  confirmationButtonLoading?: boolean;
+  showNavigationButtons?: boolean;
+}
+
+export const SummaryPage = ({
+  delegableApis,
+  delegableOrgs,
+  failedDelegations,
+  successfulDelegations,
+  pageHeaderText,
+  headerColor = 'dark',
+  headerIcon,
+  topListText,
+  failedDelegationText,
+  bottomListText,
+  bottomText,
+  confirmationButtonClick,
+  confirmationButtonDisabled = false,
+  confirmationButtonLoading = false,
+  restartProcessPath,
+  showNavigationButtons = true,
+}: SummaryPageProps) => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  const delegableApiListItems = delegableApis?.map(
+    (api: DelegableApi | ApiDelegation, index: Key) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          startIcon={<SettingsIcon />}
+          removeCallback={delegableApis.length > 1 ? () => dispatch(softRemoveApi(api)) : null}
+          leftText={api.apiName}
+          middleText={api.orgName}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const delegableOrgListItems = delegableOrgs?.map(
+    (org: DelegableOrg, index: Key | null | undefined) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          startIcon={<OfficeIcon />}
+          removeCallback={delegableOrgs.length > 1 ? () => dispatch(softRemoveOrg(org)) : null}
+          leftText={org.orgName}
+          middleText={t('api_delegation.org_nr') + ' ' + org.orgNr}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const failedDelegatedListItems = failedDelegations?.map(
+    (apiDelegation: ApiDelegation, index: Key | null | undefined) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          contentColor={ListTextColor.error}
+          middleText={apiDelegation.apiName}
+          leftText={apiDelegation.orgName}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const successfulDelegatedItems = successfulDelegations?.map(
+    (apiDelegation: ApiDelegation, index: Key | null | undefined) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          middleText={apiDelegation.apiName}
+          leftText={apiDelegation.orgName}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const showTopSection = () => {
+    return (
+      (delegableApis !== null && delegableApis !== undefined && delegableApis?.length > 0) ||
+      (failedDelegations !== null &&
+        failedDelegations !== undefined &&
+        failedDelegations?.length > 0)
+    );
+  };
+
+  const showBottomSection = () => {
+    return (
+      (delegableOrgs !== null && delegableOrgs !== undefined && delegableOrgs?.length > 0) ||
+      (successfulDelegations !== null &&
+        successfulDelegations !== undefined &&
+        successfulDelegations?.length > 0)
+    );
+  };
+
+  const showErrorPanel = () => {
+    return !showTopSection() && !showBottomSection();
+  };
+
+  const navigateToOverview = () => {
+    dispatch(setOveviewToReload());
+    navigate('/' + ApiDelegationPath.OfferedApiDelegations + '/' + ApiDelegationPath.Overview);
+  };
+
+  return (
+    <Page
+      color={headerColor}
+      size={isSm ? 'small' : 'medium'}
+    >
+      <PageHeader icon={headerIcon}>{pageHeaderText}</PageHeader>
+      <PageContent>
+        {showErrorPanel() ? (
+          <Panel
+            title={t('common.error')}
+            variant={PanelVariant.Error}
+            forceMobileLayout={isSm}
+            showIcon={!isSm}
+          >
+            <div>
+              <p>{t('api_delegation.delegations_not_registered')}</p>
+              <div className={classes.restartButton}>
+                <Button
+                  variant='outline'
+                  color='danger'
+                  onClick={() => {
+                    navigate(restartProcessPath);
+                  }}
+                >
+                  {t('common.restart')}
+                </Button>
+              </div>
+            </div>
+          </Panel>
+        ) : (
+          <div>
+            {showTopSection() && (
+              <div>
+                <h2 className={classes.listText}>{topListText}</h2>
+                {delegableApiListItems !== undefined && (
+                  <List borderStyle={'dashed'}>{delegableApiListItems}</List>
+                )}
+                {failedDelegations !== undefined && (
+                  <List borderStyle={'dashed'}>{failedDelegatedListItems}</List>
+                )}
+              </div>
+            )}
+            <h3 className={classes.infoText}>{failedDelegationText}</h3>
+            {showBottomSection() && (
+              <div>
+                <h2 className={classes.bottomListText}>{bottomListText}</h2>
+                {delegableOrgs !== undefined && (
+                  <List borderStyle={'dashed'}>{delegableOrgListItems}</List>
+                )}
+                {successfulDelegations !== undefined && (
+                  <List borderStyle={'dashed'}>{successfulDelegatedItems}</List>
+                )}
+              </div>
+            )}
+            <h3 className={classes.infoText}>{bottomText}</h3>
+            {showNavigationButtons ? (
+              <NavigationButtons
+                previousPath={
+                  '/' + ApiDelegationPath.OfferedApiDelegations + '/' + ApiDelegationPath.ChooseApi
+                }
+                previousText={t('api_delegation.previous')}
+                nextPath={
+                  '/' + ApiDelegationPath.OfferedApiDelegations + '/' + ApiDelegationPath.Receipt
+                }
+                nextText={t('common.confirm')}
+                nextDisabled={confirmationButtonDisabled}
+                nextLoading={confirmationButtonLoading}
+                nextButtonColor='success'
+                nextButtonClick={confirmationButtonClick}
+              ></NavigationButtons>
+            ) : (
+              <div className={classes.receiptMainButton}>
+                <Button
+                  color='primary'
+                  variant='filled'
+                  onClick={navigateToOverview}
+                  fullWidth={isSm}
+                >
+                  {t('api_delegation.receipt_page_main_button')}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </PageContent>
+    </Page>
+  );
+};

--- a/frontend/src/features/overviewpage/components/SummaryPage/index.ts
+++ b/frontend/src/features/overviewpage/components/SummaryPage/index.ts
@@ -1,0 +1,1 @@
+export { SummaryPage } from './SummaryPage';

--- a/frontend/src/features/overviewpage/index.ts
+++ b/frontend/src/features/overviewpage/index.ts
@@ -1,0 +1,1 @@
+export { OverviewPage } from './OverviewPage';

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -1,17 +1,20 @@
 import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router-dom';
 import * as React from 'react';
 
+import { OverviewPage as AuthenticationOverviewPage } from '@/features/overviewpage/OverviewPage';
+
 import { ChooseApiPage } from '@/features/apiDelegation/offered/ChooseApiPage';
 import { OverviewPage as OfferedOverviewPage } from '@/features/apiDelegation/offered/OverviewPage';
 import { OverviewPage as ReceivedOverviewPage } from '@/features/apiDelegation/received/OverviewPage';
 import { ChooseOrgPage } from '@/features/apiDelegation/offered/ChooseOrgPage';
 import { ReceiptPage } from '@/features/apiDelegation/offered/ReceiptPage';
 import { ConfirmationPage } from '@/features/apiDelegation/offered/ConfirmationPage';
-import { NotFoundSite } from '@/sites/NotFoundSite';
 import { ChooseServicePage } from '@/features/singleRight/delegate/ChooseServicePage/ChooseServicePage';
 import { ChooseRightsPage } from '@/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage';
 
-import { GeneralPath, SingleRightPath, ApiDelegationPath } from '../paths';
+import { NotFoundSite } from '@/sites/NotFoundSite';
+
+import { GeneralPath, AuthenticationPath, SingleRightPath, ApiDelegationPath } from '../paths';
 
 // Note: there are just 8 pages: the elaborate and repetitive route tree below
 // maps out URLs such as /Basepath/OfferedApiDelegations/Overview
@@ -46,10 +49,20 @@ export const Router = createBrowserRouter(
       errorElement={<NotFoundSite />}
     >
       <Route
+        path={AuthenticationPath.Auth}
+        errorElement={<NotFoundSite />}
+      >
+        <Route
+          path={AuthenticationPath.Overview}
+          element={<AuthenticationOverviewPage />}
+          errorElement={<NotFoundSite />}
+        />
+      </Route>
+
+      <Route
         path={ApiDelegationPath.OfferedApiDelegations}
         errorElement={<NotFoundSite />}
       >
-
         <Route
           path={ApiDelegationPath.Overview}
           element={<OfferedOverviewPage />}

--- a/frontend/src/routes/paths/AuthenticationPath.tsx
+++ b/frontend/src/routes/paths/AuthenticationPath.tsx
@@ -1,0 +1,4 @@
+export enum AuthenticationPath {
+    Overview = 'overview',
+    Auth = 'auth',
+  }

--- a/frontend/src/routes/paths/index.ts
+++ b/frontend/src/routes/paths/index.ts
@@ -1,3 +1,4 @@
 export { ApiDelegationPath } from './ApiDelegationPath';
 export { GeneralPath } from './GeneralPath';
 export { SingleRightPath } from './SingleRightPath';
+export { AuthenticationPath } from './AuthenticationPath';


### PR DESCRIPTION
## Description
The draft overview page as described in issue #2 
has now an independent path tree, 
and is reachable at http://localhost:5173/authfront/ui/auth/overview

## Related Issue(s)
- #2

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] README of /frontend/ is updated
