### PR TITLE
CreationPage created with own path and link from OverviewPage

### DIFF
--- a/frontend/src/features/creationpage/CreationPage.tsx
+++ b/frontend/src/features/creationpage/CreationPage.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+
+import { Page, PageHeader, PageContent, PageContainer } from '@/components';
+import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
+import { useMediaQuery } from '@/resources/hooks';
+
+import { OverviewPageContent } from './components/OverviewPageContent';
+import { LayoutState } from './components/LayoutState';
+
+export const CreationPage = () => {
+  const { t } = useTranslation('common');
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  // fix-me: set language key in <PageHeader>
+
+  return (
+    <PageContainer>
+      <Page
+        color='dark'
+        size={isSm ? 'small' : 'medium'}
+      >
+        <PageHeader icon={<ApiIcon />}>{'Opprett ny systembruker'}</PageHeader>
+        <PageContent>
+          <OverviewPageContent layout={LayoutState.Offered} />
+        </PageContent>
+      </Page>
+    </PageContainer>
+  );
+};

--- a/frontend/src/features/creationpage/components/LayoutState.tsx
+++ b/frontend/src/features/creationpage/components/LayoutState.tsx
@@ -1,0 +1,4 @@
+export enum LayoutState {
+  Offered,
+  Received,
+}

--- a/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.module.css
+++ b/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.module.css
@@ -1,0 +1,37 @@
+@media only screen and (max-width: 768px) {
+  .actionBarContent {
+    padding-left: 0.7rem;
+  }
+
+  .orgDelegationActionBarTitle {
+    font-size: 14px;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .actionBarContent {
+    padding-left: 50px;
+  }
+}
+
+.actionBarContent {
+  padding-right: 10px;
+}
+
+.actionBarText__softDelete {
+  text-decoration: line-through;
+  opacity: 70%;
+}
+
+.actionBarSubtitle__softDelete {
+  text-decoration: line-through;
+  opacity: 70%;
+}
+
+.accordionHeaderRightText {
+  margin-right: 15px;
+}
+
+.additionalText {
+  margin-right: 10px;
+}

--- a/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.test.cy.tsx
+++ b/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.test.cy.tsx
@@ -1,0 +1,313 @@
+import { Provider } from 'react-redux';
+import { mount } from 'cypress/react18';
+import * as React from 'react';
+
+import { OrgDelegationActionBar } from '@/features/apiDelegation/components/OverviewPageContent/OrgDelegationActionBar';
+import store from '@/rtk/app/store';
+
+import type { OverviewOrg } from '@/rtk/features/apiDelegation/apiDelegation/overviewOrg/overviewOrgSlice';
+
+Cypress.Commands.add('mount', (component, options = {}) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { reduxStore = store, ...mountOptions } = options as any;
+
+  const wrapped = <Provider store={reduxStore}>{component}</Provider>;
+
+  return mount(wrapped, mountOptions);
+});
+
+describe('OrgDelegationActionBar', () => {
+  describe('AccordionHeader', () => {
+    it('should show delegateNewApi-button on render when delegateToOrgCallback is set', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={false}
+          delegateToOrgCallback={() => null}
+        />,
+      );
+      cy.findByRole('button', { name: /api_delegation.delegate_new_api/i }).should('exist');
+    });
+
+    it('should not show delegateNewApi-button on render when delegateToOrgCallback is not set', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={false}
+        />,
+      );
+      cy.findByRole('button', { name: /api_delegation.delegate_new_api/i }).should('not.exist');
+    });
+
+    it('should show delete button when state isEditable=true', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={true}
+        />,
+      );
+      cy.findByRole('button', { name: /delete/i }).should('exist');
+    });
+
+    it('should not show undo button when state is isEditable=false', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={false}
+        />,
+      );
+      cy.findByRole('button', { name: /undo/i }).should('not.exist');
+    });
+
+    it('should show an undo button and display header with line through when all apis are soft deleted', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: true,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: true,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: true,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      cy.mount(
+        <OrgDelegationActionBar
+          softRestoreAllCallback={() => null}
+          softDeleteAllCallback={() => null}
+          organization={overviewOrgs}
+          isEditable={true}
+        />,
+      );
+
+      cy.get('button')
+        .contains('Evry')
+        .should('have.css', 'text-decoration', 'line-through solid rgb(30, 43, 60)');
+      cy.findByRole('button', { name: /undo/i }).should('exist');
+    });
+
+    it('should call softDeleteCallback on button click and isEditable=true ', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: false,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      const softDeleteAll = () => {
+        cy.stub();
+      };
+
+      const softDeleteAllSpy = cy.spy(softDeleteAll).as('softDeleteAllSpy');
+
+      cy.mount(
+        <OrgDelegationActionBar
+          organization={overviewOrgs}
+          softDeleteAllCallback={softDeleteAllSpy}
+          softRestoreAllCallback={() => null}
+          isEditable={true}
+        />,
+      );
+
+      cy.findByRole('button', { name: /delete/i }).click();
+      cy.get('@softDeleteAllSpy').should('have.been.called');
+    });
+
+    it('should call softRestoreCallback on buttonclick', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: true,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      const softRestoreAll = () => {
+        cy.stub();
+      };
+
+      const softRestoreAllSpy = cy.spy(softRestoreAll).as('softRestoreAllSpy');
+
+      cy.mount(
+        <OrgDelegationActionBar
+          organization={overviewOrgs}
+          softDeleteAllCallback={() => null}
+          softRestoreAllCallback={softRestoreAllSpy}
+          isEditable={true}
+        />,
+      );
+
+      cy.findByRole('button', { name: /undo/i }).click();
+      cy.get('@softRestoreAllSpy').should('have.been.called');
+    });
+
+    it('should call delegateToOrgCallback on buttonclick', () => {
+      const overviewOrgs: OverviewOrg = {
+        id: '1',
+        orgName: 'Evry',
+        isAllSoftDeleted: true,
+        orgNr: '123456789',
+        apiList: [
+          {
+            id: '1',
+            apiName: 'Delegert API A',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+          {
+            id: '2',
+            apiName: 'Delegert API B',
+            isSoftDelete: false,
+            owner: 'Accenture',
+            description:
+              'API for forvaltningsorgan og kompetansesenter som skal styrke kommunenes, sektormyndighetenes og andre samarbeidspartneres kompetanse på integrering og',
+          },
+        ],
+      };
+
+      const delegateToNewOrg = () => {
+        cy.stub();
+      };
+
+      const delegateToNewOrgSpy = cy.spy(delegateToNewOrg).as('delegateToNewOrgSpy');
+
+      cy.mount(
+        <OrgDelegationActionBar
+          organization={overviewOrgs}
+          softDeleteAllCallback={() => null}
+          softRestoreAllCallback={() => null}
+          delegateToOrgCallback={delegateToNewOrgSpy}
+          isEditable={true}
+        />,
+      );
+
+      cy.findByRole('button', { name: /delegate_new_api/i }).click();
+      cy.get('@delegateToNewOrgSpy').should('have.been.called');
+    });
+  });
+});

--- a/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.tsx
+++ b/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { Button, List } from '@digdir/design-system-react';
+import cn from 'classnames';
+import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+
+import type { OverviewOrg } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
+import { softDelete, softRestore } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
+import { useAppDispatch } from '@/rtk/app/hooks';
+import { ReactComponent as MinusCircle } from '@/assets/MinusCircle.svg';
+import { ReactComponent as Cancel } from '@/assets/Cancel.svg';
+import { ReactComponent as AddCircle } from '@/assets/AddCircle.svg';
+import { DeletableListItem, ActionBar } from '@/components';
+import { useMediaQuery } from '@/resources/hooks';
+
+import classes from './OrgDelegationActionBar.module.css';
+
+export interface OrgDelegationActionBarProps {
+  organization: OverviewOrg;
+  isEditable: boolean;
+  softRestoreAllCallback: () => void;
+  softDeleteAllCallback: () => void;
+  delegateToOrgCallback?: () => void;
+}
+
+export const OrgDelegationActionBar = ({
+  organization,
+  softRestoreAllCallback,
+  softDeleteAllCallback,
+  isEditable = false,
+  delegateToOrgCallback,
+}: OrgDelegationActionBarProps) => {
+  const [open, setOpen] = useState(false);
+  const { t } = useTranslation('common');
+  const numberOfAccesses = organization.apiList.length.toString();
+  const dispatch = useAppDispatch();
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  const handleSoftDeleteAll = () => {
+    softDeleteAllCallback();
+    setOpen(true);
+  };
+
+  const actions = (
+    <>
+      {delegateToOrgCallback && (
+        <Button
+          variant={'quiet'}
+          color={'primary'}
+          icon={<AddCircle />}
+          size={'medium'}
+          onClick={delegateToOrgCallback}
+          aria-label={String(t('api_delegation.delegate_new_api'))}
+        >
+          {t('api_delegation.delegate_new_api')}
+        </Button>
+      )}
+      {isEditable &&
+        (organization.isAllSoftDeleted ? (
+          <Button
+            variant={'quiet'}
+            color={'secondary'}
+            size={'medium'}
+            icon={<Cancel />}
+            onClick={softRestoreAllCallback}
+            aria-label={String(t('common.undo')) + ' ' + organization.orgName}
+          >
+            {!isSm && t('common.undo')}
+          </Button>
+        ) : (
+          <div>
+            <Button
+              variant={'quiet'}
+              color={'danger'}
+              icon={<MinusCircle />}
+              size={'medium'}
+              onClick={handleSoftDeleteAll}
+              aria-label={String(t('api_delegation.delete')) + ' ' + organization.orgName}
+            >
+              {!isSm && t('api_delegation.delete')}
+            </Button>
+          </div>
+        ))}
+    </>
+  );
+
+  const listItems = organization.apiList.map((item, i) => (
+    <DeletableListItem
+      key={i}
+      softDeleteCallback={() => dispatch(softDelete([organization.id, item.id]))}
+      softRestoreCallback={() => dispatch(softRestore([organization.id, item.id]))}
+      item={item}
+      isEditable={isEditable}
+      scopes={item.scopes}
+    ></DeletableListItem>
+  ));
+
+  return (
+    <ActionBar
+      headingLevel={3}
+      onClick={() => {
+        setOpen(!open);
+      }}
+      open={open}
+      color={'neutral'}
+      actions={actions}
+      title={
+        <div
+          className={cn(classes.orgDelegationActionBarTitle, {
+            [classes.actionBarText__softDelete]: organization.isAllSoftDeleted,
+          })}
+        >
+          {organization.orgName}
+        </div>
+      }
+      subtitle={
+        <div
+          className={cn({
+            [classes.actionBarSubtitle__softDelete]: organization.isAllSoftDeleted,
+          })}
+        >
+          {t('api_delegation.org_nr') + ' ' + organization.orgNr}
+        </div>
+      }
+      additionalText={
+        <div
+          className={cn(classes.additionalText, {
+            [classes.actionBarText__softDelete]: organization.isAllSoftDeleted,
+          })}
+        >
+          {!isSm && (
+            <span>
+              {numberOfAccesses} {t('api_delegation.api_accesses')}
+            </span>
+          )}
+        </div>
+      }
+    >
+      <div className={classes.actionBarContent}>
+        <List borderStyle={'solid'}>{listItems}</List>
+      </div>
+    </ActionBar>
+  );
+};

--- a/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/index.ts
+++ b/frontend/src/features/creationpage/components/OverviewPageContent/OrgDelegationActionBar/index.ts
@@ -1,0 +1,1 @@
+export { OrgDelegationActionBar } from './OrgDelegationActionBar';

--- a/frontend/src/features/creationpage/components/OverviewPageContent/OverviewPageContent.module.css
+++ b/frontend/src/features/creationpage/components/OverviewPageContent/OverviewPageContent.module.css
@@ -1,0 +1,107 @@
+@media only screen and (max-width: 768px) {
+  .overviewAccordionsContainer {
+    margin-top: 0rem;
+  }
+
+  .delegateNewButton {
+    margin-bottom: 1.3rem;
+    margin-top: 0rem;
+  }
+
+  .activeDelegationsHeader {
+    margin-top: 0.1rem;
+  }
+
+  .editButton {
+    align-items: center;
+    justify-content: end;
+    margin-bottom: 0.3rem;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .overviewActionBarContainer {
+    margin-top: 3rem;
+  }
+
+  .delegateNewButton {
+    margin-bottom: 3rem;
+  }
+
+  .activeDelegationsHeader {
+    margin-top: 2rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .saveSection {
+    margin-right: 0.5rem;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .editButton {
+    justify-content: flex-end;
+    align-items: center;
+    display: flex;
+    flex: 1;
+  }
+
+  .explanatoryContainer {
+    margin-top: 30px;
+    display: flex;
+  }
+}
+
+.noActiveDelegations {
+  margin-top: 1.5rem;
+}
+
+.spinnerContainer {
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+.saveSection {
+  margin-top: 2rem;
+}
+
+.apiSubheading {
+  display: flex;
+  margin-bottom: 2rem;
+  font-weight: 500;
+}
+
+.pageContentText {
+  margin-top: -2rem;
+  font-weight: 500;
+}
+
+.link {
+  color: black;
+  text-decoration-line: underline;
+  text-decoration-color: #1eadf7;
+  display: inline-block;
+  background: transparent;
+}
+
+.errorPanel {
+  margin-top: 2rem;
+}
+
+.actionBarWrapper {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.testText {
+  margin-right: 40px;
+}
+
+.testContent {
+  margin: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}

--- a/frontend/src/features/creationpage/components/OverviewPageContent/OverviewPageContent.tsx
+++ b/frontend/src/features/creationpage/components/OverviewPageContent/OverviewPageContent.tsx
@@ -158,22 +158,64 @@ export const OverviewPageContent = ({
         <br></br>
       </div>
 
-      <div><p>Input boks Navn</p></div> 
+      <table>
+        <tr>
+          <td>
+            
+            <p>Navn</p> 
+            <p>XXXXX INPUT BOKS XXXXX</p> 
+            <br></br>
+            <p>Beskrivelse</p> 
+            <p>XXXXX INPUT BOKS XXXXX</p>    
 
-      <div><p>Input boks Beskrivelse</p></div>      
+            <p> </p> 
 
-      <div>
-        <br></br><br></br><br></br>
-      </div>
+           
+            <div>
+              <br></br><br></br><br></br>
+              <br></br><br></br><br></br>
+              <br></br><br></br><br></br>
+              <br></br><br></br><br></br>
+              <br></br><br></br>
+              
+            </div>
+          
+            <p>____________________________________________ </p> 
+          
+          </td>
 
-      {!isSm && <h2 className={classes.pageContentText}>
-        {'Du har tidligere opprettet disse systembrukerne'} 
-      </h2>} 
-        
+          <td>
+            <p>
+              En systembruker kan i utgangspunktet kun benyttes av Pølsebu AS sine 
+              egne maskinporten-klienter. 
+              <a href="https://altinn.github.io/docs/"> Les mer her</a> og  
+              <a href="https://docs.altinn.studio/nb/"> her</a>. 
+            </p>
+            <p>
+              Ved å velge en systemleverandør vil opprettet systembruker kunne 
+              benyttes fra leverandørens system. Leverandørens system vil da ha 
+              fullmaktene tildelt til systembrukeren.
+            </p>
+            <br></br>
+
+            <p>Velg systemleverandør</p>
+            <p>NEDTREKKSMENY</p>
+            <p>Microsoft Norge PowerBI</p>
+            <p>Visma SuperTax</p>
+            <p>Aqua Nor Aqua Master</p>
+            <p>Fiken Business Power</p>
+            <p>PostNord Strålboks</p>
+
+            <br></br><br></br>
+
+            <p> AVBRYT-KNAPP _____  OPPRETT-KNAPP</p>
+
+          </td>
+        </tr>
+      </table>
 
       
 
-      
 
     </div>
   );

--- a/frontend/src/features/creationpage/components/OverviewPageContent/index.ts
+++ b/frontend/src/features/creationpage/components/OverviewPageContent/index.ts
@@ -1,0 +1,1 @@
+export { OverviewPageContent } from './OverviewPageContent';

--- a/frontend/src/features/creationpage/components/SummaryPage/SummaryPage.module.css
+++ b/frontend/src/features/creationpage/components/SummaryPage/SummaryPage.module.css
@@ -1,0 +1,63 @@
+@media only screen and (max-width: 768px) {
+  .receiptMainButton {
+    width: 100%;
+  }
+
+  .listText {
+    font-size: 20px;
+  }
+
+  .bottomListText {
+    font-size: 20px;
+    margin-top: 2.5rem;
+  }
+
+  .infoText {
+    font-size: 16px;
+  }
+}
+
+.receiptMainButton {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.navButtonContainer {
+  margin-top: 8rem;
+  display: flex;
+  justify-content: end;
+  margin-bottom: 70px;
+}
+
+.previousButton {
+  display: flex;
+  margin-right: 3rem;
+}
+
+.confirmButton {
+  display: flex;
+}
+
+.infoText {
+  margin-top: 20px;
+  font-weight: 400;
+}
+
+.listText {
+  font-weight: 500;
+}
+
+.bottomListText {
+  font-weight: 500;
+  margin-top: 2.5rem;
+}
+
+.restartButton {
+  display: flex;
+  justify-content: center;
+}
+
+.receiptMainButton {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/src/features/creationpage/components/SummaryPage/SummaryPage.tsx
+++ b/frontend/src/features/creationpage/components/SummaryPage/SummaryPage.tsx
@@ -1,0 +1,240 @@
+import { Panel, PanelVariant } from '@altinn/altinn-design-system';
+import { List, Button } from '@digdir/design-system-react';
+import type { Key } from 'react';
+import { t } from 'i18next';
+import { useNavigate } from 'react-router-dom';
+import * as React from 'react';
+
+import { useAppDispatch } from '@/rtk/app/hooks';
+import { ReactComponent as OfficeIcon } from '@/assets/Office1.svg';
+import { ReactComponent as SettingsIcon } from '@/assets/Settings.svg';
+import {
+  CompactDeletableListItem,
+  NavigationButtons,
+  Page,
+  PageContent,
+  PageHeader,
+  type PageColor,
+} from '@/components';
+import type { ApiDelegation } from '@/rtk/features/apiDelegation/delegationRequest/delegationRequestSlice';
+import type { DelegableOrg } from '@/rtk/features/apiDelegation/delegableOrg/delegableOrgSlice';
+import { softRemoveOrg } from '@/rtk/features/apiDelegation/delegableOrg/delegableOrgSlice';
+import { softRemoveApi } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
+import type { DelegableApi } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
+import { useMediaQuery } from '@/resources/hooks/useMediaQuery';
+import { ApiDelegationPath } from '@/routes/paths';
+import { setLoading as setOveviewToReload } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
+
+import { ListTextColor } from '../../../../components/CompactDeletableListItem/CompactDeletableListItem';
+
+import classes from './SummaryPage.module.css';
+
+export interface SummaryPageProps {
+  delegableApis?: DelegableApi[];
+  delegableOrgs?: DelegableOrg[];
+  failedDelegations?: ApiDelegation[];
+  successfulDelegations?: ApiDelegation[];
+  restartProcessPath: string;
+  pageHeaderText: string;
+  headerIcon: React.ReactNode;
+  headerColor?: PageColor;
+  topListText?: string;
+  failedDelegationText?: string;
+  bottomListText?: string;
+  bottomText?: string;
+  confirmationButtonClick?: () => void;
+  confirmationButtonDisabled?: boolean;
+  confirmationButtonLoading?: boolean;
+  showNavigationButtons?: boolean;
+}
+
+export const SummaryPage = ({
+  delegableApis,
+  delegableOrgs,
+  failedDelegations,
+  successfulDelegations,
+  pageHeaderText,
+  headerColor = 'dark',
+  headerIcon,
+  topListText,
+  failedDelegationText,
+  bottomListText,
+  bottomText,
+  confirmationButtonClick,
+  confirmationButtonDisabled = false,
+  confirmationButtonLoading = false,
+  restartProcessPath,
+  showNavigationButtons = true,
+}: SummaryPageProps) => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  const delegableApiListItems = delegableApis?.map(
+    (api: DelegableApi | ApiDelegation, index: Key) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          startIcon={<SettingsIcon />}
+          removeCallback={delegableApis.length > 1 ? () => dispatch(softRemoveApi(api)) : null}
+          leftText={api.apiName}
+          middleText={api.orgName}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const delegableOrgListItems = delegableOrgs?.map(
+    (org: DelegableOrg, index: Key | null | undefined) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          startIcon={<OfficeIcon />}
+          removeCallback={delegableOrgs.length > 1 ? () => dispatch(softRemoveOrg(org)) : null}
+          leftText={org.orgName}
+          middleText={t('api_delegation.org_nr') + ' ' + org.orgNr}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const failedDelegatedListItems = failedDelegations?.map(
+    (apiDelegation: ApiDelegation, index: Key | null | undefined) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          contentColor={ListTextColor.error}
+          middleText={apiDelegation.apiName}
+          leftText={apiDelegation.orgName}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const successfulDelegatedItems = successfulDelegations?.map(
+    (apiDelegation: ApiDelegation, index: Key | null | undefined) => {
+      return (
+        <CompactDeletableListItem
+          key={index}
+          middleText={apiDelegation.apiName}
+          leftText={apiDelegation.orgName}
+        ></CompactDeletableListItem>
+      );
+    },
+  );
+
+  const showTopSection = () => {
+    return (
+      (delegableApis !== null && delegableApis !== undefined && delegableApis?.length > 0) ||
+      (failedDelegations !== null &&
+        failedDelegations !== undefined &&
+        failedDelegations?.length > 0)
+    );
+  };
+
+  const showBottomSection = () => {
+    return (
+      (delegableOrgs !== null && delegableOrgs !== undefined && delegableOrgs?.length > 0) ||
+      (successfulDelegations !== null &&
+        successfulDelegations !== undefined &&
+        successfulDelegations?.length > 0)
+    );
+  };
+
+  const showErrorPanel = () => {
+    return !showTopSection() && !showBottomSection();
+  };
+
+  const navigateToOverview = () => {
+    dispatch(setOveviewToReload());
+    navigate('/' + ApiDelegationPath.OfferedApiDelegations + '/' + ApiDelegationPath.Overview);
+  };
+
+  return (
+    <Page
+      color={headerColor}
+      size={isSm ? 'small' : 'medium'}
+    >
+      <PageHeader icon={headerIcon}>{pageHeaderText}</PageHeader>
+      <PageContent>
+        {showErrorPanel() ? (
+          <Panel
+            title={t('common.error')}
+            variant={PanelVariant.Error}
+            forceMobileLayout={isSm}
+            showIcon={!isSm}
+          >
+            <div>
+              <p>{t('api_delegation.delegations_not_registered')}</p>
+              <div className={classes.restartButton}>
+                <Button
+                  variant='outline'
+                  color='danger'
+                  onClick={() => {
+                    navigate(restartProcessPath);
+                  }}
+                >
+                  {t('common.restart')}
+                </Button>
+              </div>
+            </div>
+          </Panel>
+        ) : (
+          <div>
+            {showTopSection() && (
+              <div>
+                <h2 className={classes.listText}>{topListText}</h2>
+                {delegableApiListItems !== undefined && (
+                  <List borderStyle={'dashed'}>{delegableApiListItems}</List>
+                )}
+                {failedDelegations !== undefined && (
+                  <List borderStyle={'dashed'}>{failedDelegatedListItems}</List>
+                )}
+              </div>
+            )}
+            <h3 className={classes.infoText}>{failedDelegationText}</h3>
+            {showBottomSection() && (
+              <div>
+                <h2 className={classes.bottomListText}>{bottomListText}</h2>
+                {delegableOrgs !== undefined && (
+                  <List borderStyle={'dashed'}>{delegableOrgListItems}</List>
+                )}
+                {successfulDelegations !== undefined && (
+                  <List borderStyle={'dashed'}>{successfulDelegatedItems}</List>
+                )}
+              </div>
+            )}
+            <h3 className={classes.infoText}>{bottomText}</h3>
+            {showNavigationButtons ? (
+              <NavigationButtons
+                previousPath={
+                  '/' + ApiDelegationPath.OfferedApiDelegations + '/' + ApiDelegationPath.ChooseApi
+                }
+                previousText={t('api_delegation.previous')}
+                nextPath={
+                  '/' + ApiDelegationPath.OfferedApiDelegations + '/' + ApiDelegationPath.Receipt
+                }
+                nextText={t('common.confirm')}
+                nextDisabled={confirmationButtonDisabled}
+                nextLoading={confirmationButtonLoading}
+                nextButtonColor='success'
+                nextButtonClick={confirmationButtonClick}
+              ></NavigationButtons>
+            ) : (
+              <div className={classes.receiptMainButton}>
+                <Button
+                  color='primary'
+                  variant='filled'
+                  onClick={navigateToOverview}
+                  fullWidth={isSm}
+                >
+                  {t('api_delegation.receipt_page_main_button')}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </PageContent>
+    </Page>
+  );
+};

--- a/frontend/src/features/creationpage/components/SummaryPage/index.ts
+++ b/frontend/src/features/creationpage/components/SummaryPage/index.ts
@@ -1,0 +1,1 @@
+export { SummaryPage } from './SummaryPage';

--- a/frontend/src/features/creationpage/index.ts
+++ b/frontend/src/features/creationpage/index.ts
@@ -1,0 +1,1 @@
+export { CreationPage } from './CreationPage';

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -51,7 +51,9 @@
     "auth_new_system_user_opprett": "Opprett ny systembruker",
     "auth_card_title_tidligere_opprettet": "Du har tidligere opprettet disse systembrukerne",
     "auth_api_panel_content": "Her skulle vært en liste over systembrukere",
-    "auth_edit_button_systembruker": "Rediger systembruker"
+    "auth_edit_button_systembruker": "Rediger systembruker",
+
+    "auth_overview_text_creation": "Opprett ny systembruker for systemintegrasjon ved bruk av Maskinporten"
   },
     
   "api_delegation": {

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, createRoutesFromElements, Route } from 'react-rout
 import * as React from 'react';
 
 import { OverviewPage as AuthenticationOverviewPage } from '@/features/overviewpage/OverviewPage';
+import { CreationPage } from '@/features/creationpage/CreationPage';
 
 import { ChooseApiPage } from '@/features/apiDelegation/offered/ChooseApiPage';
 import { OverviewPage as OfferedOverviewPage } from '@/features/apiDelegation/offered/OverviewPage';
@@ -57,7 +58,17 @@ export const Router = createBrowserRouter(
           element={<AuthenticationOverviewPage />}
           errorElement={<NotFoundSite />}
         />
+
+        <Route
+          path={AuthenticationPath.Creation}
+          element={<CreationPage />}
+          errorElement={<NotFoundSite />}
+        />
+        
       </Route>
+
+
+
 
       <Route
         path={ApiDelegationPath.OfferedApiDelegations}

--- a/frontend/src/routes/paths/AuthenticationPath.tsx
+++ b/frontend/src/routes/paths/AuthenticationPath.tsx
@@ -1,4 +1,5 @@
 export enum AuthenticationPath {
-    Overview = 'overview',
-    Auth = 'auth',
-  }
+  Auth = 'auth',
+  Creation = 'creation',
+  Overview = 'overview'
+}


### PR DESCRIPTION
## Description
The first draft of the mock CreationPage is now reachable from the OverviewPage.

Note: the structure has so far no CSS, and the input machinery is yet missing.


## Related Issue(s)
- #19 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
