### PR TITLE
Reactivate api calls for RefreshToken fretchUserInfo and fetchReportee

### DIFF
--- a/frontend/src/components/UserInfoBar/UserInfoBar.tsx
+++ b/frontend/src/components/UserInfoBar/UserInfoBar.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 
 import { ReactComponent as AltinnLogo } from '@/assets/AltinnTextLogo.svg';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-// import { fetchUserInfo, fetchReportee } from '@/rtk/features/userInfo/userInfoSlice';
+import { fetchUserInfo, fetchReportee } from '@/rtk/features/userInfo/userInfoSlice';
 
 import classes from './UserInfoBar.module.css';
 
@@ -16,14 +16,12 @@ export const UserInfoBar = () => {
   const reporteeLoading = useAppSelector((state) => state.userInfo.reporteeLoading);
   const dispatch = useAppDispatch();
 
-  /*
   useEffect(() => {
     if (userLoading || reporteeLoading) {
       void dispatch(fetchUserInfo());
       void dispatch(fetchReportee());
     }
   }, []);
-  */
 
   return (
     <div>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,7 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { use } from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-// import { RefreshToken } from '@/resources/Token/RefreshToken'; // temp inactivaiton 19.09.23
+import { RefreshToken } from '@/resources/Token/RefreshToken';
 import { Router } from '@/routes/Router/Router';
 
 import { getConfig } from '../config';

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -44,7 +44,6 @@ use(LanguageDetector)
         defaultOptions: import.meta.env.DEV ? queryClientDevDefaults : undefined,
       });
 
-      // temp inactivation 19.09.23: <RefreshToken />
       ReactDOM.createRoot(document.getElementById('root')).render(
         // if you ever wonder why the components render twice it's because of React.StrictMode
         // comment it out if it causes trouble: https://react.dev/reference/react/StrictMode
@@ -52,7 +51,7 @@ use(LanguageDetector)
           <Provider store={store}>
             <QueryClientProvider client={queryClient}>
               <LoadLocalizations>
-                
+                <RefreshToken />
                 <RouterProvider router={Router}></RouterProvider>
               </LoadLocalizations>
             </QueryClientProvider>


### PR DESCRIPTION
## Description
In order to use the BFF the inactivated API calls, 
such as RefreshToken, fetchUserInfo and fetchReportee,
must be reactivated.

## Related Issue(s)
- #8 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
