### PR TITLE
Update documentation on communication between running bff and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# altinn-authentication-frontend
-Authentication React frontend with BFF
+# altinn-authentication-frontend repo
+Dette er Authentication React frontend med BFF (backend-for-frontend)
+
+# Hvordan sette opp bff app og frontend app så de kjører sammen
+Det er nå fungerende kontakt mellom kjørende React frontend og BFF apper, <br>
+som var et viktig først delmål for utvikling av løsningen.
+
+Om en kjører opp React frontend med Vite server <br>
+(se README i /frontend/ sub-repo), <br>
+
+og kjører opp BFF med Kestrel server
+(se README i /bff/ sub-repo, men kort sagt, kjør 
+> dotnet run <br>
+der .csproj filen er)
+
+så er SWAGGER oversikt over API tilgjengelig i browser på 
+http://localhost:5191/swagger/index.html
+
+og vår frontend Overview side tilgjengelig på 
+http://localhost:5191/authfront/ui/auth/overview
+
+Dette fungerer nå både på Mac og på PC.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# altinn-authentication-frontend repo
+# Altinn-authentication-frontend repo
 Dette er Authentication React frontend med BFF (backend-for-frontend)
 
 # Hvordan sette opp bff app og frontend app så de kjører sammen

--- a/bff/README.md
+++ b/bff/README.md
@@ -13,4 +13,24 @@ The BFF exposes as set of APIs for the React SPA, with the customized (re-mapped
 on the routes: /authfront/api/* These APIs are all re-mapped (proxied) from the "real" Altinn APIs deeper into Altinn.
 
 
+### How-to-run the bff app for development purposes 
+
+You should have dotnet 7 installed. The frontend app should be <br>
+running the Vite server (see README How-to-run in /frontend/ sub-repo)<br>
+
+The bff dotnet app is runnable, and reachable by browser,<br>
+in brief, by development Kestrel server, by 
+> dotnet run
+
+in folder with .csproj file:  
+(altinn-authentication-frontend/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI)
+
+Swagger API overview, and OverviewPage should then become available at:<br>
+http://localhost:5191/swagger/index.html <br>
+http://localhost:5191/authfront/ui/auth/overview <br>
+
+That is, the bff dotnet app is serving the frontend javascript "bundles", <b>
+but piece-by-piece via the Vite server (see README /frontend/ ).
+
+
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,7 +3,7 @@ This is the React frontend part of the new altinn-authentication-frontend.<br>
 A more detailed description of the project is available at this repo wiki.
 
 
-## How-to-use this app per. 27.09.23 (this is a work in progress):
+## How-to-use this app per 29.09.23 (this is a work in progress):
 
 Corepack should be installed and enabled, 
 https://nodejs.org/api/corepack.html <br>
@@ -41,6 +41,15 @@ This should install the dependencies listed in package.json
 
 4. Run the Vite webserver script in package.json by
 > yarn start
+
+The bff dotnet app is also available (see README in /bff/ sub-repo),<br>
+in brief, in order to reach deveopment Kestrel server, do 
+> dotnet run
+in folder with .csproj file. 
+
+Swagger and OverviewPage should then become available at:<br>
+http://localhost:5191/swagger/index.html <br>
+http://localhost:5191/authfront/ui/auth/overview <br>
 
 ### Links to new pages and paths in the new app
 


### PR DESCRIPTION
## Description
Our bff app and React frontend apps can now run and successfully communicate while running.

This was an important sub-goal for development.

The documentation of How-to-run the apps and reach the apps, have been updated in 
README in sub-repos, and main repo.

## Related Issue(s)
- #7
- #8 


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
