### PR TITLE
First version of Maskinporten admin page

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.module.css
+++ b/frontend/src/features/creationpage/CreationPageContent.module.css
@@ -43,6 +43,8 @@
 
 .buttonContainer {
   display: flex;
+  justify-content: flex-end;
+  margin-top: 40px;
 }
 
 .cancelButton {

--- a/frontend/src/features/creationpage/CreationPageContent.module.css
+++ b/frontend/src/features/creationpage/CreationPageContent.module.css
@@ -39,20 +39,25 @@
 
 .confirmationWrapper {
   margin: 10px;
+  margin-top: 50px;
+  font-size: 10px;
 }
 
 .buttonContainer {
   display: flex;
   justify-content: flex-end;
-  margin-top: 40px;
+  margin-top: 10px;
+  
 }
 
 .cancelButton {
   margin: 10px;
+  display: flex;
 }
 
 .confirmButton {
   margin: 10px;
+  display: flex;
 }
 
 @media only screen and (min-width: 769px) {

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -21,9 +21,25 @@ export const CreationPageContent = () => {
   const [navn, setNavn] = useState('');
   const [beskrivelse, setBeskrivelse] = useState('');
 
-
   // State variabel for nedtrekksmeny:
   const [selected, setSelected] = useState(''); 
+
+  const handleReject = () => {
+    setNavn('');
+    setBeskrivelse('');
+    setSelected('');
+  }
+
+  // Mulig at her skal man trigge en dispatch
+  // og så navigere til OverviewPage
+  const handleConfirm = () => {
+    setNavn('ReduxLagret');
+    setBeskrivelse('ReduxLagret');
+    setSelected('');
+  }
+
+
+  
 
   const { t } = useTranslation('common');
   const navigate = useNavigate();
@@ -83,6 +99,7 @@ export const CreationPageContent = () => {
   };
   // const minInputId:string = "inputIdString"; // valg id trengs ikke?
  
+ 
 
   return (
     <div className={classes.creationPageContainer}>
@@ -130,15 +147,21 @@ export const CreationPageContent = () => {
             />
           </div>
 
-          <hr></hr>
+          
             
           <div className={classes.confirmationWrapper}>
+
+            <hr></hr>
+
             <p>
-              <b>Bekreft valgt systemleverandør : {selected}</b>
+              <b>Bekreft valgt systemleverandør : </b> <br></br>
+              {selected} 
               <br></br>
-              <b>Bekreft navn ny systembruker : {navn}</b>
+              <b>Bekreft navn ny systembruker : </b> <br></br>
+              {navn} 
               <br></br>
-              <b>Bekreft beskrivelse ny systembruker: {beskrivelse}</b>
+              <b>Bekreft beskrivelse ny systembruker: </b> <br></br>
+              {beskrivelse} 
 
             </p>
           </div>
@@ -150,6 +173,7 @@ export const CreationPageContent = () => {
                 color='primary'
                 variant='outline'
                 size='small'
+                onClick={handleReject}
               >
                 Avbryt 
               </Button> 
@@ -159,6 +183,7 @@ export const CreationPageContent = () => {
               <Button
                 color='primary'
                 size='small'
+                onClick={handleConfirm}
               >
                 Opprett 
               </Button> 

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -32,6 +32,8 @@ export const CreationPageContent = () => {
 
   // Mulig at her skal man trigge en dispatch
   // og så navigere til OverviewPage
+  // har opprettet en creationPageSlice som nå er synlig i 
+  // Chrome DevTools --> må ut og løpe...
   const handleConfirm = () => {
     setNavn('ReduxLagret');
     setBeskrivelse('ReduxLagret');

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -1,11 +1,12 @@
-import { TextField, Button, Select } from '@digdir/design-system-react';
+import * as React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
-import * as React from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { AuthenticationPath } from '@/routes/paths';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { TextField, Button, Select } from '@digdir/design-system-react';
+import classes from './CreationPageContent.module.css';
 import { useMediaQuery } from '@/resources/hooks';
-import classes from './CreationPageContent.module.css'; // ikke redigert ennå
 
 // NOTE! this version of OverviewPageContent is for CreationPage
 // CreationPage with sub-files must be reorganized and renamed
@@ -20,10 +21,25 @@ export const CreationPageContent = () => {
   // State variabel for nedtrekksmeny:
   const [selected, setSelected] = useState(''); 
 
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch(); // fix-me: bygg kobling til REDUX 
+  // const overviewOrgs = useAppSelector((state) => state.overviewOrg.overviewOrgs);
+  
+
+  // brukes i h2, ikke vist i Small/mobile view
+  const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
+  let overviewText: string;
+  overviewText = t('authentication_dummy.auth_overview_text_creation'); 
+
+
+  // skal nå bare gå tilbake til OverviewPage
+  // selv om vi må vurdere en sletting av ting?
   const handleReject = () => {
     setNavn('');
     setBeskrivelse('');
     setSelected('');
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
   // Mulig at her skal man trigge en dispatch
@@ -39,15 +55,6 @@ export const CreationPageContent = () => {
 
   
 
-  const { t } = useTranslation('common');
-  const navigate = useNavigate();
-  const dispatch = useAppDispatch(); // fix-me: bygg kobling til REDUX 
-  // const overviewOrgs = useAppSelector((state) => state.overviewOrg.overviewOrgs);
-  const isSm = useMediaQuery('(max-width: 768px)');
-
-  // brukes i h2, ikke vist i Small/mobile view
-  let overviewText: string;
-  overviewText = t('authentication_dummy.auth_overview_text_creation'); 
 
   // options med label skilt fra value (samme verdi for demo)
   // use inline interface definition for Type her
@@ -96,6 +103,13 @@ export const CreationPageContent = () => {
     setSelected(val);
   };
   // const minInputId:string = "inputIdString"; // valg id trengs ikke?
+
+  // Dette er mest for knapper og videre navigering,
+  // mens her er <Link> kanskje bedre: fra Studio Dashboard
+  // men bør også sjekke Designsystemet om de har noe på gang der
+  const handleSkiftTilCustomCreationPage = () => {
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.CustomCreation);
+  };
  
  
 
@@ -137,9 +151,11 @@ export const CreationPageContent = () => {
           </p>
 
           <p className={classes.contentText}>
-            For å velge en SELVVALGT systemleverandør klikk  
-            <a href="https://vg.no"
-            > her</a>.
+            For å velge en SELVVALGT systemleverandør klikk 
+            <Link
+            to={'/' + AuthenticationPath.Auth + '/' + AuthenticationPath.CustomCreation}
+            > her</Link> 
+
           </p>
 
           <div className={classes.selectWrapper}>
@@ -151,25 +167,7 @@ export const CreationPageContent = () => {
             />
           </div>
 
-          
-            
-          <div className={classes.confirmationWrapper}>
-
-            <hr></hr>
-
-            <p>
-              <b>Bekreft valgt systemleverandør : </b> <br></br>
-              {selected} 
-              <br></br>
-              <b>Bekreft navn ny systembruker : </b> <br></br>
-              {navn} 
-              <br></br>
-              <b>Bekreft beskrivelse ny systembruker: </b> <br></br>
-              {beskrivelse} 
-
-            </p>
-          </div>
-
+    
           <div className={classes.buttonContainer}>
 
             <div className={classes.cancelButton}>

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -147,21 +147,25 @@ export const CreationPageContent = () => {
 
             <div className={classes.cancelButton}>
               <Button
-                color='danger'
+                color='primary'
+                variant='outline'
+                size='small'
               >
-                AVBRYT 
+                Avbryt 
               </Button> 
             </div>
 
             <div className={classes.confirmButton}>
               <Button
-                color='success'
+                color='primary'
+                size='small'
               >
-                OPPRETT 
+                Opprett 
               </Button> 
             </div>
 
           </div>
+
         </div>      
       </div>
     </div>

--- a/frontend/src/features/customCreationPage/CustomCreationPage.tsx
+++ b/frontend/src/features/customCreationPage/CustomCreationPage.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+
+import { Page, PageHeader, PageContent, PageContainer } from '@/components';
+import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
+import { useMediaQuery } from '@/resources/hooks';
+
+import { CustomCreationPageContent } from './CustomCreationPageContent';
+
+
+export const CustomCreationPage = () => {
+  const { t } = useTranslation('common');
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  // fix-me: set language key in <PageHeader>
+
+  return (
+    <PageContainer>
+      <Page
+        color='dark'
+        size={isSm ? 'small' : 'medium'}
+      >
+        <PageHeader icon={<ApiIcon />}>{'Opprett ny SPESIAL-systembruker'}</PageHeader>
+        <PageContent>
+          <CustomCreationPageContent />
+        </PageContent>
+      </Page>
+    </PageContainer>
+  );
+};

--- a/frontend/src/features/customCreationPage/CustomCreationPageContent.module.css
+++ b/frontend/src/features/customCreationPage/CustomCreationPageContent.module.css
@@ -1,4 +1,4 @@
-.creationPageContainer {
+.customCreationPageContainer {
   margin-left: 40px;
   margin-right: 40px;
   margin-top: 3rem;

--- a/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
+++ b/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
@@ -5,13 +5,12 @@ import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { useMediaQuery } from '@/resources/hooks';
-import classes from './CreationPageContent.module.css'; // ikke redigert ennå
+import classes from './CustomCreationPageContent.module.css'; 
 
-// NOTE! this version of OverviewPageContent is for CreationPage
-// CreationPage with sub-files must be reorganized and renamed
+// Kopiert fra CreationPage: mye må ryddes vekk her og
+// erstattes med Runes spesialflyt #3
 
-
-export const CreationPageContent = () => {
+export const CustomCreationPageContent = () => {
   
   // State variabler for input-bokser:
   const [navn, setNavn] = useState('');
@@ -100,13 +99,13 @@ export const CreationPageContent = () => {
  
 
   return (
-    <div className={classes.creationPageContainer}>
+    <div className={classes.customCreationPageContainer}>
       <h2 className={classes.header}>{overviewText}</h2>  
       <div className={classes.flexContainer}>
         <div className={classes.leftContainer}>
           <div className={classes.nameWrapper}>
             <TextField 
-              label = 'Navn'
+              label = 'Navn: spesial'
               value = { navn }
               onChange={e => setNavn(e.target.value)}
             />
@@ -114,7 +113,7 @@ export const CreationPageContent = () => {
 
           <div className={classes.descriptionWrapper}>
             <TextField 
-              label= 'Beskrivelse' 
+              label= 'Beskrivelse av spesial' 
               value = { beskrivelse }
               onChange={e => setBeskrivelse(e.target.value)}
             />
@@ -131,20 +130,20 @@ export const CreationPageContent = () => {
           </p>
 
           <p className={classes.contentText}>
-            Ved å velge en FORHÅNDSGODKJENT systemleverandør vil opprettet systembruker kunne 
-            benyttes fra leverandørens system. Leverandørens system vil da ha 
+            Du er i gang med å opprette en SELV-VALGT leverandør. 
+            Den SELV-VALGTE leverandørens system vil da ha 
             fullmaktene tildelt til systembrukeren.
           </p>
 
           <p className={classes.contentText}>
-            For å velge en SELVVALGT systemleverandør klikk  
+            For å velge en FORHÅNDSGODKJENT systemleverandør klikk  
             <a href="https://vg.no"
             > her</a>.
           </p>
 
           <div className={classes.selectWrapper}>
             <Select
-              label="Velg FORHÅNDSGODKJENT systemleverandør"
+              label="Velg SELV-VALGT systemleverandør"
               options={testoptions}
               onChange={handleChangeInput}
               value={selected}
@@ -158,7 +157,7 @@ export const CreationPageContent = () => {
             <hr></hr>
 
             <p>
-              <b>Bekreft valgt systemleverandør : </b> <br></br>
+              <b>Bekreft SELV-VALGT systemleverandør : </b> <br></br>
               {selected} 
               <br></br>
               <b>Bekreft navn ny systembruker : </b> <br></br>

--- a/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
+++ b/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
@@ -139,6 +139,7 @@ export const CustomCreationPageContent = () => {
               options={testoptions}
               onChange={handleChangeInput}
               value={selected}
+              error={true}
             />
           </div>
 

--- a/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
+++ b/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
@@ -119,16 +119,11 @@ export const CustomCreationPageContent = () => {
         <div className={classes.rightContainer}>
 
           <p className={classes.contentText}>
-            En systembruker kan i utgangspunktet kun benyttes av Pølsebu AS sine 
-            egne maskinporten-klienter. 
-            <a href="https://altinn.github.io/docs/"> Les mer her</a> og  
-            <a href="https://docs.altinn.studio/nb/"> her</a>. 
-          </p>
-
-          <p className={classes.contentText}>
             Du er i gang med å opprette en SELV-VALGT leverandør. 
             Den SELV-VALGTE leverandørens system vil da ha 
-            fullmaktene tildelt til systembrukeren.
+            fullmaktene tildelt til systembrukeren. Systembrukeren må 
+            knyttes mot organisasjonens egen integrasjon i maskinporten
+            eller et system tilbydt av en selv-valgt leverandør. 
           </p>
 
           <p className={classes.contentText}>
@@ -140,7 +135,7 @@ export const CustomCreationPageContent = () => {
 
           <div className={classes.selectWrapper}>
             <Select
-              label="Velg SELV-VALGT systemleverandør"
+              label="Velg maskinporten integrasjon"
               options={testoptions}
               onChange={handleChangeInput}
               value={selected}

--- a/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
+++ b/frontend/src/features/customCreationPage/CustomCreationPageContent.tsx
@@ -1,11 +1,12 @@
-import { TextField, Button, Select } from '@digdir/design-system-react';
+import * as React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
-import * as React from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { AuthenticationPath } from '@/routes/paths';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { useMediaQuery } from '@/resources/hooks';
+import { TextField, Button, Select } from '@digdir/design-system-react';
 import classes from './CustomCreationPageContent.module.css'; 
+import { useMediaQuery } from '@/resources/hooks';
 
 // Kopiert fra CreationPage: mye må ryddes vekk her og
 // erstattes med Runes spesialflyt #3
@@ -19,10 +20,24 @@ export const CustomCreationPageContent = () => {
   // State variabel for nedtrekksmeny:
   const [selected, setSelected] = useState(''); 
 
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch(); // fix-me: bygg kobling til REDUX 
+  // const overviewOrgs = useAppSelector((state) => state.overviewOrg.overviewOrgs);
+  
+  // brukes i h2, ikke vist i Small/mobile view
+  const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
+  let overviewText: string;
+  overviewText = t('authentication_dummy.auth_overview_text_creation'); 
+
+
+  // skal nå bare gå tilbake til OverviewPage
+  // selv om vi må vurdere en sletting av ting?
   const handleReject = () => {
     setNavn('');
     setBeskrivelse('');
     setSelected('');
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
   // Mulig at her skal man trigge en dispatch
@@ -38,16 +53,7 @@ export const CustomCreationPageContent = () => {
 
   
 
-  const { t } = useTranslation('common');
-  const navigate = useNavigate();
-  const dispatch = useAppDispatch(); // fix-me: bygg kobling til REDUX 
-  // const overviewOrgs = useAppSelector((state) => state.overviewOrg.overviewOrgs);
-  const isSm = useMediaQuery('(max-width: 768px)');
-
-  // brukes i h2, ikke vist i Small/mobile view
-  let overviewText: string;
-  overviewText = t('authentication_dummy.auth_overview_text_creation'); 
-
+  
   // options med label skilt fra value (samme verdi for demo)
   // use inline interface definition for Type her
   // https://stackoverflow.com/questions/35435042/how-can-i-define-an-array-of-objects
@@ -57,26 +63,16 @@ export const CustomCreationPageContent = () => {
       "value": ""
     },
     {
-      "label": "Microsoft Norge PowerBI",
-      "value": "Microsoft Norge PowerBI"
+      "label": "SELV-VALGT VALG1",
+      "value": "SELV-VALGT VALG1"
     },
     {
-      "label": "Visma SuperTax",
-      "value": "Visma SuperTax"
+      "label": "SELV-VALGT VALG2",
+      "value": "SELV-VALGT VALG2"
     },
-    {
-      "label": "Aqua Nor Aqua Master",
-      "value": "Aqua Nor Aqua Master"
-    },
-    {
-      "label": "Fiken Business Power",
-      "value": "Fiken Business Power"
-    },
-    {
-      "label": "PostNord Strålboks",
-      "value": "PostNord Strålboks"
-    }
-  ]; // merk at Storyboard dokumentasjon på Designsystemet
+  ]; 
+  
+  // merk at Storyboard dokumentasjon på Designsystemet SELECT
   // skiller mellom "label" og "value"
   // "value er verdien som brukes av onChange-funksjonen.
   // label er teksten som vises i listen.""
@@ -137,8 +133,9 @@ export const CustomCreationPageContent = () => {
 
           <p className={classes.contentText}>
             For å velge en FORHÅNDSGODKJENT systemleverandør klikk  
-            <a href="https://vg.no"
-            > her</a>.
+            <Link
+            to={'/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Creation}
+            > her</Link> 
           </p>
 
           <div className={classes.selectWrapper}>
@@ -152,22 +149,7 @@ export const CustomCreationPageContent = () => {
 
           
             
-          <div className={classes.confirmationWrapper}>
-
-            <hr></hr>
-
-            <p>
-              <b>Bekreft SELV-VALGT systemleverandør : </b> <br></br>
-              {selected} 
-              <br></br>
-              <b>Bekreft navn ny systembruker : </b> <br></br>
-              {navn} 
-              <br></br>
-              <b>Bekreft beskrivelse ny systembruker: </b> <br></br>
-              {beskrivelse} 
-
-            </p>
-          </div>
+         
 
           <div className={classes.buttonContainer}>
 

--- a/frontend/src/features/customCreationPage/index.ts
+++ b/frontend/src/features/customCreationPage/index.ts
@@ -1,0 +1,1 @@
+export { CustomCreationPage } from './CustomCreationPage';

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPage.tsx
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPage.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+
+import { Page, PageHeader, PageContent, PageContainer } from '@/components';
+import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
+import { useMediaQuery } from '@/resources/hooks';
+
+import { MaskinportenIntAdmPageContent } from './MaskinportenIntAdmPageContent';
+
+
+export const MaskinportenIntAdmPage = () => {
+  const { t } = useTranslation('common');
+  const isSm = useMediaQuery('(max-width: 768px)');
+
+  // fix-me: set language key in <PageHeader>
+
+  return (
+    <PageContainer>
+      <Page
+        color='dark'
+        size={isSm ? 'small' : 'medium'}
+      >
+        <PageHeader icon={<ApiIcon />}>{'Administrere maskinporten integrasjoner'}</PageHeader>
+        <PageContent>
+          <MaskinportenIntAdmPageContent />
+        </PageContent>
+      </Page>
+    </PageContainer>
+  );
+};

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
@@ -18,31 +18,24 @@
   margin-right: 1rem;
 }
 
-.rightContainer {
-  flex: 3;
-}
 
 .nameWrapper {
   margin: 10px;
+  max-width: 270px;
+
 }
 
 .descriptionWrapper {
   margin: 10px;
   margin-top: 2rem;
+  max-width: 270px;
 }
 
-.selectWrapper {
-  margin: 10px;
-  margin-bottom: 2rem;
-  margin-top: 2rem;
-
+.warningUpdateText {
+  font-size: 12px;
 }
 
-.confirmationWrapper {
-  margin: 10px;
-  margin-top: 50px;
-  font-size: 10px;
-}
+
 
 .buttonContainer {
   display: flex;

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
@@ -1,0 +1,98 @@
+.creationPageContainer {
+  margin-left: 40px;
+  margin-right: 40px;
+  margin-top: 3rem;
+}
+
+.header {
+  margin-top: -2rem;
+  font-weight: 500;
+}
+
+.flexContainer {
+  display: flex;
+}
+
+.leftContainer {
+  flex: 3;
+  margin-right: 1rem;
+}
+
+.rightContainer {
+  flex: 3;
+}
+
+.nameWrapper {
+  margin: 10px;
+}
+
+.descriptionWrapper {
+  margin: 10px;
+  margin-top: 2rem;
+}
+
+.selectWrapper {
+  margin: 10px;
+  margin-bottom: 2rem;
+  margin-top: 2rem;
+
+}
+
+.confirmationWrapper {
+  margin: 10px;
+  margin-top: 50px;
+  font-size: 10px;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+  
+}
+
+.cancelButton {
+  margin: 10px;
+  display: flex;
+}
+
+.confirmButton {
+  margin: 10px;
+  display: flex;
+}
+
+@media only screen and (min-width: 769px) {
+
+  .contentText {
+    font-size: 18px;
+  }
+  
+}
+
+@media only screen and (max-width: 768px) {
+
+  .contentText {
+    font-size: 16px;
+  }
+
+}
+
+@media only screen and (max-width: 576px) {
+
+  .flexContainer {
+    flex-direction: column;
+  }
+
+  .creationPageContainer {
+    margin-top: 1rem;
+  }
+
+  .header {
+    font-size: 20px;
+  }
+
+  .contentText {
+    font-size: 14px;
+  }
+
+}

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
@@ -27,8 +27,8 @@ export const MaskinportenIntAdmPageContent = () => {
   // brukes i h2, ikke vist i Small/mobile view
   const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
   let overviewText: string;
-  overviewText = t('authentication_dummy.auth_overview_text_creation'); 
-
+  // overviewText = t('authentication_dummy.auth_overview_text_creation'); 
+  overviewText = 'Opprett og administrer maskinporten integrasjon'; // flytt til språkstøtte
 
   // skal nå bare gå tilbake til OverviewPage
   // selv om vi må vurdere en sletting av ting?
@@ -74,6 +74,7 @@ export const MaskinportenIntAdmPageContent = () => {
           <div className={classes.nameWrapper}>
             <TextField 
               label = 'Navn'
+              type = 'text'
               value = { navn }
               onChange={e => setNavn(e.target.value)}
             />
@@ -82,6 +83,7 @@ export const MaskinportenIntAdmPageContent = () => {
           <div className={classes.descriptionWrapper}>
             <TextField 
               label= 'Beskrivelse' 
+              type = 'text'
               value = { beskrivelse }
               onChange={e => setBeskrivelse(e.target.value)}
             />
@@ -89,12 +91,29 @@ export const MaskinportenIntAdmPageContent = () => {
 
           <p className={classes.contentText}>
             
-            Last opp i jwk i format
-
-            HER EN KNAPP MED LABEL
+          <br></br>
+            Last opp i jwk i format <br></br>
             
-            Maskinporten krever at du oppdaterer JWK hver 12. månd.
-            Hvis JWK ikke oppdateres vil integrasjon slutte å virke.
+            <div className={classes.uploadButton}>
+              <Button
+                color='primary'
+                variant='outline'
+                size='small'
+                onClick={handleReject}
+              >
+                Choose File 
+              </Button>
+              <span>No file chosen</span> 
+            </div>
+            <br></br>
+            
+          </p>
+
+          <p className={classes.warningUpdateText}>
+            <b>
+              Maskinporten krever at du oppdaterer JWK hver 12. måned.
+              Hvis JWK ikke oppdateres vil integrasjon slutte å virke.
+            </b>
           </p>
 
           <div className={classes.buttonContainer}>

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, Link } from 'react-router-dom';
+import { AuthenticationPath } from '@/routes/paths';
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { TextField, Button, Select } from '@digdir/design-system-react';
+import classes from './MaskinportenIntAdmPageContent.module.css';
+import { useMediaQuery } from '@/resources/hooks';
+
+
+export const MaskinportenIntAdmPageContent = () => {
+  
+  // State variabler for input-bokser:
+  const [navn, setNavn] = useState('');
+  const [beskrivelse, setBeskrivelse] = useState('');
+
+  // State variabel for nedtrekksmeny:
+  const [selected, setSelected] = useState(''); 
+
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch(); // fix-me: bygg kobling til REDUX 
+  // const overviewOrgs = useAppSelector((state) => state.overviewOrg.overviewOrgs);
+  
+
+  // brukes i h2, ikke vist i Small/mobile view
+  const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
+  let overviewText: string;
+  overviewText = t('authentication_dummy.auth_overview_text_creation'); 
+
+
+  // skal nå bare gå tilbake til OverviewPage
+  // selv om vi må vurdere en sletting av ting?
+  const handleReject = () => {
+    setNavn('');
+    setBeskrivelse('');
+    setSelected('');
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  }
+
+  // Mulig at her skal man trigge en dispatch
+  // og så navigere til OverviewPage
+  // har opprettet en creationPageSlice som nå er synlig i 
+  // Chrome DevTools --> må ut og løpe...
+  const handleConfirm = () => {
+    setNavn('ReduxLagret');
+    setBeskrivelse('ReduxLagret');
+    setSelected('');
+  }
+
+
+  
+  
+  // Håndterer skifte av valgmuligheter (options) i Nedtrekksmeny
+  const handleChangeInput = (val: string) => {
+    setSelected(val);
+  };
+  // const minInputId:string = "inputIdString"; // valg id trengs ikke?
+
+  // Dette er mest for knapper og videre navigering,
+  // mens her er <Link> kanskje bedre: fra Studio Dashboard
+  // men bør også sjekke Designsystemet om de har noe på gang der
+  const handleSkiftTilCustomCreationPage = () => {
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.CustomCreation);
+  };
+ 
+  return (
+    <div className={classes.creationPageContainer}>
+      <h2 className={classes.header}>{overviewText}</h2>  
+      <div className={classes.flexContainer}>
+        
+        <div className={classes.leftContainer}>
+          <div className={classes.nameWrapper}>
+            <TextField 
+              label = 'Navn'
+              value = { navn }
+              onChange={e => setNavn(e.target.value)}
+            />
+          </div>
+
+          <div className={classes.descriptionWrapper}>
+            <TextField 
+              label= 'Beskrivelse' 
+              value = { beskrivelse }
+              onChange={e => setBeskrivelse(e.target.value)}
+            />
+          </div>
+
+          <p className={classes.contentText}>
+            
+            Last opp i jwk i format
+
+            HER EN KNAPP MED LABEL
+            
+            Maskinporten krever at du oppdaterer JWK hver 12. månd.
+            Hvis JWK ikke oppdateres vil integrasjon slutte å virke.
+          </p>
+
+          <div className={classes.buttonContainer}>
+
+            <div className={classes.cancelButton}>
+              <Button
+                color='primary'
+                variant='outline'
+                size='small'
+                onClick={handleReject}
+              >
+                Avbryt 
+              </Button> 
+            </div>
+
+            <div className={classes.confirmButton}>
+              <Button
+                color='primary'
+                size='small'
+                onClick={handleConfirm}
+              >
+                Opprett 
+              </Button> 
+            </div>
+
+          </div>
+          
+        </div>
+
+              
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/maskinportenIntAdm/index.ts
+++ b/frontend/src/features/maskinportenIntAdm/index.ts
@@ -1,0 +1,1 @@
+export { MaskinportenIntAdmPage } from './MaskinportenIntAdmPage';

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 
 import { OverviewPage as AuthenticationOverviewPage } from '@/features/overviewpage/OverviewPage';
 import { CreationPage } from '@/features/creationpage/CreationPage';
+import { CustomCreationPage } from '@/features/customCreationPage/CustomCreationPage';
+
 import { DirectConsentPage } from '@/features/directconsentpage/DirectConsentPage';
 
 import { NotFoundSite } from '@/sites/NotFoundSite';
@@ -33,10 +35,17 @@ export const Router = createBrowserRouter(
         />
 
         <Route
+          path={AuthenticationPath.CustomCreation}
+          element={<CustomCreationPage />}
+          errorElement={<NotFoundSite />}
+        />
+
+        <Route
           path={AuthenticationPath.DirectConsent}
           element={<DirectConsentPage />}
           errorElement={<NotFoundSite />}
         />
+
         
       </Route>
     </Route>,

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -4,9 +4,8 @@ import * as React from 'react';
 import { OverviewPage as AuthenticationOverviewPage } from '@/features/overviewpage/OverviewPage';
 import { CreationPage } from '@/features/creationpage/CreationPage';
 import { CustomCreationPage } from '@/features/customCreationPage/CustomCreationPage';
-
 import { DirectConsentPage } from '@/features/directconsentpage/DirectConsentPage';
-
+import { MaskinportenIntAdmPage } from '@/features/maskinportenIntAdm/MaskinportenIntAdmPage';
 import { NotFoundSite } from '@/sites/NotFoundSite';
 import { GeneralPath, AuthenticationPath } from '../paths';
 
@@ -43,6 +42,12 @@ export const Router = createBrowserRouter(
         <Route
           path={AuthenticationPath.DirectConsent}
           element={<DirectConsentPage />}
+          errorElement={<NotFoundSite />}
+        />
+
+        <Route
+          path={AuthenticationPath.MaskinportenAdm}
+          element={<MaskinportenIntAdmPage />}
           errorElement={<NotFoundSite />}
         />
 

--- a/frontend/src/routes/paths/AuthenticationPath.tsx
+++ b/frontend/src/routes/paths/AuthenticationPath.tsx
@@ -1,6 +1,7 @@
 export enum AuthenticationPath {
   Auth = 'auth',
   Creation = 'creation',
+  CustomCreation = 'customcreation',
   Overview = 'overview',
   DirectConsent = 'directconsent'
 }

--- a/frontend/src/routes/paths/AuthenticationPath.tsx
+++ b/frontend/src/routes/paths/AuthenticationPath.tsx
@@ -3,5 +3,6 @@ export enum AuthenticationPath {
   Creation = 'creation',
   CustomCreation = 'customcreation',
   Overview = 'overview',
-  DirectConsent = 'directconsent'
+  DirectConsent = 'directconsent',
+  MaskinportenAdm = 'maskinportenadm'
 }

--- a/frontend/src/rtk/app/store.ts
+++ b/frontend/src/rtk/app/store.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
 import userInfoReducer from '../features/userInfo/userInfoSlice';
+import creationPageReducer from '../features/creationPage/creationPageSlice';
 
 const logger = createLogger();
 
@@ -9,11 +10,13 @@ const store = import.meta.env.PROD
   ? configureStore({
       reducer: {
         userInfo: userInfoReducer,
+        creationPage: creationPageReducer,
       },
     })
   : configureStore({
       reducer: {
         userInfo: userInfoReducer,
+        creationPage: creationPageReducer,
       },
       middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware().concat(logger),

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -1,0 +1,40 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export interface SliceState {
+    navn: string;
+  beskrivelse: string;
+  selected: string;
+}
+
+const initialState: SliceState = {
+    navn: 'test-initial',
+    beskrivelse: 'test-initial', 
+    selected: 'test-initial',
+};
+
+/* Not sure if CreationPage needs to fetch information
+export const fetchUserInfo = createAsyncThunk('userInfo/fetchUserInfoSlice', async () => {
+  return await axios
+    .get('/authfront/api/v1/profile/user')
+    .then((response) => response.data)
+    .catch((error) => {
+      console.error(error);
+      throw new Error(String(error.response.data));
+    });
+});
+*/
+
+const creationPageSlice = createSlice({
+  name: 'creation',
+  initialState,
+  reducers: {
+    lagreKnapper : (state, action) => {
+        state.navn = action.payload.navn;
+        state.beskrivelse = action.payload.beskrivelse;
+        state.selected = action.payload.selected;
+    }
+  },
+});
+
+export default creationPageSlice.reducer;


### PR DESCRIPTION
## Description
A first version of the new page "Administrere maskinporten integrasjoner"
is now ready. 

The page is purely visual and has no real interaction yet. That is for future iterations.

## Related Issue(s)
- #38 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
The repo wiki has been updated with the link to this page, which is
http://localhost:5191/authfront/ui/auth/maskinportenadm

