### PR TITLE
New systemUser information now stored in Redux global State and used in OverviewPage

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -3,10 +3,14 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
+
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { lagreOpprettKnapp } from '@/rtk/features/creationPage/creationPageSlice';
+
 import { TextField, Button, Select } from '@digdir/design-system-react';
 import classes from './CreationPageContent.module.css';
 import { useMediaQuery } from '@/resources/hooks';
+
 
 
 export const CreationPageContent = () => {
@@ -20,37 +24,35 @@ export const CreationPageContent = () => {
 
   const { t } = useTranslation('common');
   const navigate = useNavigate();
-  const dispatch = useAppDispatch(); // fix-me: bygg kobling til REDUX 
-  // const overviewOrgs = useAppSelector((state) => state.overviewOrg.overviewOrgs);
-  
+
+  const dispatch = useAppDispatch(); // fix-me: bygger kobling til REDUX 
+  const reduxNavn = useAppSelector((state) => state.creationPage.navn);
+  const reduxBeskrivelse = useAppSelector((state) => state.creationPage.beskrivelse);
 
   // brukes i h2, ikke vist i Small/mobile view
-  const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
+  const isSm = useMediaQuery('(max-width: 768px)'); // fix-me: trengs denne?
   let overviewText: string;
   overviewText = 'Knytt systembruker til systemleverandør'; 
 
 
   // skal nå bare gå tilbake til OverviewPage
-  // selv om vi må vurdere en sletting av ting?
   const handleReject = () => {
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  }
+
+  // Opprett-knapp flytter foreløpig bare 
+  // local State for Navn, Beskrivelse og Valgt Systemleverandør
+  // til Redux State, som er stabil så lenge app kjører
+  // ---> tilgjengelig også fra andre sider
+  // ---> API er ennå ikke tilgjengelig per 10.10.23
+  const handleConfirm = () => {
+    dispatch(lagreOpprettKnapp( { navn: navn, beskrivelse: beskrivelse, selected: selected } ));
     setNavn('');
     setBeskrivelse('');
     setSelected('');
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
-  // Mulig at her skal man trigge en dispatch
-  // og så navigere til OverviewPage
-  // har opprettet en creationPageSlice som nå er synlig i 
-  // Chrome DevTools --> må ut og løpe...
-  const handleConfirm = () => {
-    setNavn('ReduxLagret');
-    setBeskrivelse('ReduxLagret');
-    setSelected('');
-  }
-
-
-  
 
 
   // options med label skilt fra value (samme verdi for demo)
@@ -167,6 +169,18 @@ export const CreationPageContent = () => {
             > her</Link> 
             .
           </p>
+
+          <p>
+            Tester lokal useState her: <br></br>
+            navn = {navn} <br></br>
+            beskrivelse = {beskrivelse}
+          </p>
+          <p>
+            Tester Redux global State her: <br></br>
+            reduxNavn = {reduxNavn} <br></br>
+            reduxBeskrivelse = {reduxBeskrivelse}
+          </p>
+
 
           <div className={classes.buttonContainer}>
             <div className={classes.cancelButton}>

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -170,18 +170,6 @@ export const CreationPageContent = () => {
             .
           </p>
 
-          <p>
-            Tester lokal useState her: <br></br>
-            navn = {navn} <br></br>
-            beskrivelse = {beskrivelse}
-          </p>
-          <p>
-            Tester Redux global State her: <br></br>
-            reduxNavn = {reduxNavn} <br></br>
-            reduxBeskrivelse = {reduxBeskrivelse}
-          </p>
-
-
           <div className={classes.buttonContainer}>
             <div className={classes.cancelButton}>
               <Button

--- a/frontend/src/features/overviewpage/OverviewPageContent.module.css
+++ b/frontend/src/features/overviewpage/OverviewPageContent.module.css
@@ -1,31 +1,35 @@
-@media only screen and (max-width: 768px) {
-  .overviewAccordionsContainer {
-    margin-top: 0rem;
-  }
 
-  .delegateNewButton {
-    margin-bottom: 1.3rem;
-    margin-top: 0rem;
-  }
+.spinnerContainer {
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+}
 
-  .activeDelegationsHeader {
-    margin-top: 0.1rem;
-  }
+.pageContentText {
+  margin-top: -2rem;
+  font-weight: 500;
+}
 
-  .editButton {
-    align-items: center;
-    justify-content: end;
-    margin-bottom: 0.3rem;
-  }
+.link {
+  color: black;
+  text-decoration-line: underline;
+  text-decoration-color: #1eadf7;
+  display: inline-block;
+  background: transparent;
+}
+
+.actionBarWrapper {
+  margin-top: 5px;
+  margin-bottom: 5px;
 }
 
 @media only screen and (min-width: 769px) {
-  .overviewActionBarContainer {
+  .overviewPageContainer {
     margin-top: 3rem;
   }
 
-  .delegateNewButton {
-    margin-bottom: 3rem;
+  .systemUserNewButton {
+    margin-bottom: 6rem;
   }
 
   .activeDelegationsHeader {
@@ -53,55 +57,25 @@
   }
 }
 
-.noActiveDelegations {
-  margin-top: 1.5rem;
-}
 
-.spinnerContainer {
-  margin-top: 3rem;
-  display: flex;
-  justify-content: center;
-}
 
-.saveSection {
-  margin-top: 2rem;
-}
+@media only screen and (max-width: 768px) {
+  .overviewAccordionsContainer {
+    margin-top: 0rem;
+  }
 
-.apiSubheading {
-  display: flex;
-  margin-bottom: 2rem;
-  font-weight: 500;
-}
+  .systemUserNewButton {
+    margin-bottom: 3rem;
+    margin-top: 0rem;
+  }
 
-.pageContentText {
-  margin-top: -2rem;
-  font-weight: 500;
-}
+  .activeDelegationsHeader {
+    margin-top: 0.1rem;
+  }
 
-.link {
-  color: black;
-  text-decoration-line: underline;
-  text-decoration-color: #1eadf7;
-  display: inline-block;
-  background: transparent;
-}
-
-.errorPanel {
-  margin-top: 2rem;
-}
-
-.actionBarWrapper {
-  margin-top: 5px;
-  margin-bottom: 5px;
-}
-
-.testText {
-  margin-right: 40px;
-}
-
-.testContent {
-  margin: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  .editButton {
+    align-items: center;
+    justify-content: end;
+    margin-bottom: 0.3rem;
+  }
 }

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -1,14 +1,15 @@
-import { Button, Spinner } from '@digdir/design-system-react';
-import { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
+// import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { ReactComponent as Add } from '@/assets/Add.svg';
-import { useMediaQuery } from '@/resources/hooks';
 import { AuthenticationPath } from '@/routes/paths';
+
 import classes from './OverviewPageContent.module.css';
-import { ErrorPanel, CollectionBar, ActionBar } from '@/components';
+import { CollectionBar, ActionBar } from '@/components';
+import { ReactComponent as Add } from '@/assets/Add.svg';
+import { Button, Spinner } from '@digdir/design-system-react';
+import { useMediaQuery } from '@/resources/hooks';
+import { useTranslation } from 'react-i18next';
 
 
 export const OverviewPageContent = () => {
@@ -19,11 +20,13 @@ export const OverviewPageContent = () => {
   const dispatch = useAppDispatch(); // fix-me: bygger kobling til REDUX 
   const reduxNavn = useAppSelector((state) => state.creationPage.navn);
   const reduxBeskrivelse = useAppSelector((state) => state.creationPage.beskrivelse);
+  const reduxSelected = useAppSelector((state) => state.creationPage.selected);
+  
+  // dette fungerer fint --> mulig at jeg skal lage kumulativ liste over systembrukere??
+  // da måtte jeg ha en katalog av brukere, der de to alleredei OverviewPage var først,
+  // men så øker det på nedover... 
 
-
-  const isSm = useMediaQuery('(max-width: 768px)');
-
-  let fetchData: () => any;
+  const isSm = useMediaQuery('(max-width: 768px)'); // ikke i bruk lenger
 
   let overviewText: string;
   overviewText = t('authentication_dummy.auth_overview_text_administrere'); 
@@ -37,6 +40,7 @@ export const OverviewPageContent = () => {
   };
 
   // Fix-me: CollectionBar links go nowhere
+
 
   return (
     <div className={classes.overviewPageContainer}>
@@ -88,11 +92,23 @@ export const OverviewPageContent = () => {
         }
       />
 
-      <p>
-        Tester Redux global State her: <br></br>
-        reduxNavn = {reduxNavn} <br></br>
-        reduxBeskrivelse = {reduxBeskrivelse}
-      </p>
+      <div>
+        <br></br>
+      </div>
+
+      { reduxNavn && (
+      <CollectionBar
+        title=  {reduxBeskrivelse}
+        subtitle= { reduxSelected }
+        additionalText= {reduxNavn}
+        color={'neutral'}
+        collection={[]}
+        compact={isSm}
+        proceedToPath={
+          '/fixpath/'
+        }
+      />
+      )}
 
     </div>
   );

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -15,7 +15,11 @@ export const OverviewPageContent = () => {
 
   const { t } = useTranslation('common');
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
+
+  const dispatch = useAppDispatch(); // fix-me: bygger kobling til REDUX 
+  const reduxNavn = useAppSelector((state) => state.creationPage.navn);
+  const reduxBeskrivelse = useAppSelector((state) => state.creationPage.beskrivelse);
+
 
   const isSm = useMediaQuery('(max-width: 768px)');
 
@@ -35,11 +39,11 @@ export const OverviewPageContent = () => {
   // Fix-me: CollectionBar links go nowhere
 
   return (
-    <div className={classes.overviewActionBarContainer}>
+    <div className={classes.overviewPageContainer}>
 
-      {!isSm && <h2 className={classes.pageContentText}>{overviewText}</h2>}
+      <h2 className={classes.pageContentText}>{overviewText}</h2>
       
-        <div className={classes.delegateNewButton}>
+        <div className={classes.systemUserNewButton}>
           <Button
             variant='outline'
             onClick={goToStartNewSystemUser}
@@ -51,13 +55,10 @@ export const OverviewPageContent = () => {
           </Button>
         </div>
       
-      <div>
-        <br></br><br></br><br></br>
-      </div>
 
-      {!isSm && <h2 className={classes.pageContentText}>
+      <h2 className={classes.pageContentText}>
         {'Du har tidligere opprettet disse systembrukerne'} 
-      </h2>} 
+      </h2>
         
 
       <CollectionBar
@@ -86,6 +87,12 @@ export const OverviewPageContent = () => {
           '/fixpath/'
         }
       />
+
+      <p>
+        Tester Redux global State her: <br></br>
+        reduxNavn = {reduxNavn} <br></br>
+        reduxBeskrivelse = {reduxBeskrivelse}
+      </p>
 
     </div>
   );

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -1,5 +1,4 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import axios from 'axios';
+import { createSlice } from '@reduxjs/toolkit';
 
 export interface SliceState {
     navn: string;
@@ -8,28 +7,17 @@ export interface SliceState {
 }
 
 const initialState: SliceState = {
-    navn: 'test-initial',
-    beskrivelse: 'test-initial', 
-    selected: 'test-initial',
+    navn: '',
+    beskrivelse: '', 
+    selected: '',
 };
 
-/* Not sure if CreationPage needs to fetch information
-export const fetchUserInfo = createAsyncThunk('userInfo/fetchUserInfoSlice', async () => {
-  return await axios
-    .get('/authfront/api/v1/profile/user')
-    .then((response) => response.data)
-    .catch((error) => {
-      console.error(error);
-      throw new Error(String(error.response.data));
-    });
-});
-*/
-
+// foreløpig lagreOpprettKnapp skal senere gi API POST kall til BFF
 const creationPageSlice = createSlice({
   name: 'creation',
   initialState,
   reducers: {
-    lagreKnapper : (state, action) => {
+    lagreOpprettKnapp : (state, action) => {
         state.navn = action.payload.navn;
         state.beskrivelse = action.payload.beskrivelse;
         state.selected = action.payload.selected;
@@ -38,3 +26,4 @@ const creationPageSlice = createSlice({
 });
 
 export default creationPageSlice.reducer;
+export const { lagreOpprettKnapp } = creationPageSlice.actions;


### PR DESCRIPTION
## Description
Information about a new systemUser, 
added in CreatePage, such as "Navn",
"Beskrivelse", and commercial vendor,
is now stored in the Redux global state,
and is available in the OverviewPage list
of systemUsers.

Note, there are no API calls involved yet.

Redux state is stable across page changes,
but will be erased upon hard reload.


## Related Issue(s)
- #28 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
The wiki repo is updated with the new features.
