### PR TITLE
MaskinportenPage iteration3 includes cleaner CSS for wide screen and mobile view

### DIFF
--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
@@ -1,4 +1,4 @@
-.creationPageContainer {
+.maskinportenPageContainer {
   margin-left: 40px;
   margin-right: 40px;
   margin-top: 3rem;
@@ -31,8 +31,26 @@
   max-width: 270px;
 }
 
+.uploadButtonContainer {
+  display: flex;
+  margin-top: 10px;
+  align-items: center;
+}
+
+.uploadButtonWrapper {
+  margin-right: 10px;
+}
+
+.fileChosenTextWrapper {
+  font-size: 16px;
+}
+
+
+
 .warningUpdateText {
-  font-size: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 2rem;
 }
 
 
@@ -41,7 +59,6 @@
   display: flex;
   justify-content: flex-end;
   margin-top: 10px;
-  
 }
 
 .cancelButton {
@@ -56,16 +73,22 @@
 
 @media only screen and (min-width: 769px) {
 
-  .contentText {
+  .jwkContentText {
     font-size: 18px;
+    margin-top: 3rem;
   }
   
 }
 
 @media only screen and (max-width: 768px) {
 
-  .contentText {
+  .header {
+    font-size: 20px;
+  }
+
+  .jwkContentText {
     font-size: 16px;
+    margin-top: 2rem;
   }
 
 }
@@ -76,15 +99,11 @@
     flex-direction: column;
   }
 
-  .creationPageContainer {
+  .maskinportenPageContainer {
     margin-top: 1rem;
   }
 
-  .header {
-    font-size: 20px;
-  }
-
-  .contentText {
+  .jwkContentText {
     font-size: 14px;
   }
 

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
@@ -15,8 +15,6 @@ export const MaskinportenIntAdmPageContent = () => {
   const [navn, setNavn] = useState('');
   const [beskrivelse, setBeskrivelse] = useState('');
 
-  // State variabel for nedtrekksmeny:
-  const [selected, setSelected] = useState(''); 
 
   const { t } = useTranslation('common');
   const navigate = useNavigate();
@@ -25,52 +23,31 @@ export const MaskinportenIntAdmPageContent = () => {
   
 
   // brukes i h2, ikke vist i Small/mobile view
-  const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
+  // const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
   let overviewText: string;
   // overviewText = t('authentication_dummy.auth_overview_text_creation'); 
   overviewText = 'Opprett og administrer maskinporten integrasjon'; // flytt til språkstøtte
 
-  // skal nå bare gå tilbake til OverviewPage
-  // selv om vi må vurdere en sletting av ting?
   const handleReject = () => {
-    setNavn('');
-    setBeskrivelse('');
-    setSelected('');
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
   // Mulig at her skal man trigge en dispatch
   // og så navigere til OverviewPage
-  // har opprettet en creationPageSlice som nå er synlig i 
-  // Chrome DevTools --> må ut og løpe...
   const handleConfirm = () => {
     setNavn('ReduxLagret');
     setBeskrivelse('ReduxLagret');
-    setSelected('');
   }
 
 
-  
-  
-  // Håndterer skifte av valgmuligheter (options) i Nedtrekksmeny
-  const handleChangeInput = (val: string) => {
-    setSelected(val);
-  };
-  // const minInputId:string = "inputIdString"; // valg id trengs ikke?
-
-  // Dette er mest for knapper og videre navigering,
-  // mens her er <Link> kanskje bedre: fra Studio Dashboard
-  // men bør også sjekke Designsystemet om de har noe på gang der
-  const handleSkiftTilCustomCreationPage = () => {
-    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.CustomCreation);
-  };
  
   return (
-    <div className={classes.creationPageContainer}>
+    <div className={classes.maskinportenPageContainer}>
       <h2 className={classes.header}>{overviewText}</h2>  
       <div className={classes.flexContainer}>
         
         <div className={classes.leftContainer}>
+          
           <div className={classes.nameWrapper}>
             <TextField 
               label = 'Navn'
@@ -89,12 +66,13 @@ export const MaskinportenIntAdmPageContent = () => {
             />
           </div>
 
-          <p className={classes.contentText}>
-            
-          <br></br>
-            Last opp i jwk i format <br></br>
-            
-            <div className={classes.uploadButton}>
+          <p className={classes.jwkContentText}>
+            Last opp i jwk i format
+          </p>  
+
+          <div className={classes.uploadButtonContainer}>
+
+            <div className={classes.uploadButtonWrapper}>
               <Button
                 color='primary'
                 variant='outline'
@@ -102,18 +80,19 @@ export const MaskinportenIntAdmPageContent = () => {
                 onClick={handleReject}
               >
                 Choose File 
-              </Button>
+              </Button>  
+            </div>
+
+            <div className={classes.fileChosenTextWrapper}>
               <span>No file chosen</span> 
             </div>
-            <br></br>
             
-          </p>
+          </div>
+          
 
           <p className={classes.warningUpdateText}>
-            <b>
               Maskinporten krever at du oppdaterer JWK hver 12. måned.
-              Hvis JWK ikke oppdateres vil integrasjon slutte å virke.
-            </b>
+              Hvis JWK ikke oppdateres vil integrasjonen slutte å virke.
           </p>
 
           <div className={classes.buttonContainer}>


### PR DESCRIPTION
## Description
The MaskinportenPage CSS has been cleaned up,
and also been made prettier for mobile views.

The upload button now is centered with the No file chosen text. 

Some unnecessary code has been removed, and there is no 
real functionality on this page yet.

This iteration is thus mainly graphical.

## Related Issue(s)
- #38 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
