### PR TITLE
Upload of jwk certificate along with two additional key-value pairs in Form object

### DIFF
--- a/frontend/src/features/maskinportenIntAdm/FileSelector.tsx
+++ b/frontend/src/features/maskinportenIntAdm/FileSelector.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+// import { useTranslation } from 'react-i18next';
+import { Button } from '@digdir/design-system-react';
+import { UploadIcon } from '@navikt/aksel-icons';
+// import * as testids from '../../../../testing/testids';
+
+export interface IFileSelectorProps {
+  submitHandler: (file: FormData, fileName: string) => void;
+  busy: boolean;
+  formFileName: string;
+  accept?: string;
+  disabled?: boolean;
+  submitButtonRenderer?: (fileInputClickHandler: (event: any) => void) => JSX.Element;
+}
+
+function FileSelector({
+  accept,
+  formFileName,
+  busy,
+  disabled,
+  submitHandler,
+  submitButtonRenderer,
+}: IFileSelectorProps) {
+  // const { t } = useTranslation();
+
+  const defaultSubmitButtonRenderer = (fileInputClickHandler: (event: any) => void) => (
+    <Button
+      id='file-upload-button'
+      icon={<UploadIcon />}
+      onClick={fileInputClickHandler}
+      disabled={disabled}
+      variant='quiet'
+      size='small'
+    >
+      {'Skulle bli jwk upload'}
+    </Button>
+  );
+
+  const fileInput = React.useRef<HTMLInputElement>(null);
+
+  const handleSubmit = (event?: React.FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
+    const file = fileInput?.current?.files?.item(0);
+    if (file) {
+      const formData = new FormData();
+      formData.append(formFileName, file);
+      submitHandler(formData, file.name);
+    }
+  };
+
+  const handleInputChange = () => {
+    const file = fileInput?.current?.files?.item(0);
+    if (file) handleSubmit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        data-testid={'testids_fileSelectorInput'}
+        type='file'
+        id='file-upload-picker'
+        className='sr-only'
+        accept={accept}
+        ref={fileInput}
+        name={formFileName}
+        onChange={handleInputChange}
+        disabled={busy}
+        tabIndex={-1}
+      />
+      {(submitButtonRenderer ?? defaultSubmitButtonRenderer)(() => fileInput?.current?.click())}
+    </form>
+  );
+}
+
+export default FileSelector;
+FileSelector.defaultProps = {
+  accept: undefined,
+};

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.module.css
@@ -31,45 +31,6 @@
   max-width: 270px;
 }
 
-.uploadButtonContainer {
-  display: flex;
-  margin-top: 10px;
-  align-items: center;
-}
-
-.uploadButtonWrapper {
-  margin-right: 10px;
-}
-
-.fileChosenTextWrapper {
-  font-size: 16px;
-}
-
-
-
-.warningUpdateText {
-  font-size: 14px;
-  font-weight: 500;
-  margin-top: 2rem;
-}
-
-
-
-.buttonContainer {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 10px;
-}
-
-.cancelButton {
-  margin: 10px;
-  display: flex;
-}
-
-.confirmButton {
-  margin: 10px;
-  display: flex;
-}
 
 @media only screen and (min-width: 769px) {
 

--- a/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
+++ b/frontend/src/features/maskinportenIntAdm/MaskinportenIntAdmPageContent.tsx
@@ -1,76 +1,63 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, Link } from 'react-router-dom';
-import { AuthenticationPath } from '@/routes/paths';
-
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { lagreNavnBeskrivelseKnapp } from '@/rtk/features/maskinportenPage/maskinportenPageSlice';
+import { lagreNavn, lagreBeskrivelse } from '@/rtk/features/maskinportenPage/maskinportenPageSlice';
 
-import { TextField, Button, Select } from '@digdir/design-system-react';
+import { TextField } from '@digdir/design-system-react';
 import classes from './MaskinportenIntAdmPageContent.module.css';
-import { useMediaQuery } from '@/resources/hooks';
+// import { useMediaQuery } from '@/resources/hooks';
+import { UploadComponent } from './UploadComponent';
 
 
 export const MaskinportenIntAdmPageContent = () => {
   
-  // State variabler for input-bokser:
+  const { t } = useTranslation('common');
+
+  // Redux variabler
+  const dispatch = useAppDispatch(); 
+  const reduxNavn = useAppSelector((state) => state.maskinportenPage.navn);
+  const reduxBeskrivelse = useAppSelector((state) => state.maskinportenPage.beskrivelse);
+  const reduxOnJwkFileAvailable = useAppSelector((state) => state.maskinportenPage.onJwkFileAvailable);
+
+  // regulate upLoad button inside <UploadComponent />
+  let opprettKnappBlokkert = true;
+  if (reduxNavn && reduxBeskrivelse && reduxOnJwkFileAvailable ) { 
+    opprettKnappBlokkert = false;
+  } 
+
+  // State variabler brukt for dynamisk oppdatering av Navn og Beskrivelse felt 
   const [navn, setNavn] = useState('');
   const [beskrivelse, setBeskrivelse] = useState('');
 
-
-  const { t } = useTranslation('common');
-  const navigate = useNavigate();
-
-  const dispatch = useAppDispatch(); // fix-me: koble opp til API
-  const reduxNavn = useAppSelector((state) => state.maskinportenPage.navn);
-  const reduxBeskrivelse = useAppSelector((state) => state.maskinportenPage.beskrivelse);
-
+  
   // brukes i h2, ikke vist i Small/mobile view
   // const isSm = useMediaQuery('(max-width: 768px)'); // trengs denne?
   let overviewText: string;
   // overviewText = t('authentication_dummy.auth_overview_text_creation'); 
   overviewText = 'Opprett og administrer maskinporten integrasjon'; // flytt til språkstøtte
 
-  const handleReject = () => {
-    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  const handleOnBlurNavn = () => {
+    dispatch(lagreNavn( { navn: navn} ));
   }
 
- // Opprett-knapp flytter foreløpig bare 
-  // local State for Navn og Beskrivelse
-  // til Redux State, som er stabil så lenge app kjører
-  // ---> tilgjengelig også fra andre sider
-  // ---> API er ennå ikke tilgjengelig per 12.10.23
-  const handleConfirm = () => {
-    dispatch(lagreNavnBeskrivelseKnapp( { navn: navn, beskrivelse: beskrivelse } ));
-    setNavn('');
-    setBeskrivelse('');
-    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  const handleOnBlurBeskrivelse = () => {
+    dispatch(lagreBeskrivelse( { beskrivelse: beskrivelse} ));
   }
 
-  /* Inactivate test temporarily
-          <p>
-            Test av Redux:<br></br>
-            ReduxNavn = { reduxNavn } <br></br>
-            ReduxBeskrivelse = { reduxBeskrivelse }
-          </p>
-  */
-
-
- 
   return (
     <div className={classes.maskinportenPageContainer}>
       <h2 className={classes.header}>{overviewText}</h2>  
       <div className={classes.flexContainer}>
-        
-        <div className={classes.leftContainer}>
-          
+        <div className={classes.leftContainer}>      
           <div className={classes.nameWrapper}>
             <TextField 
               label = 'Navn'
               type = 'text'
               value = { navn }
-              onChange={e => setNavn(e.target.value)}
+              onChange=
+              {e => setNavn(e.target.value)}
+              onBlur = {handleOnBlurNavn}
             />
           </div>
 
@@ -80,6 +67,7 @@ export const MaskinportenIntAdmPageContent = () => {
               type = 'text'
               value = { beskrivelse }
               onChange={e => setBeskrivelse(e.target.value)}
+              onBlur = {handleOnBlurBeskrivelse}
             />
           </div>
 
@@ -87,59 +75,8 @@ export const MaskinportenIntAdmPageContent = () => {
             Last opp i jwk i format
           </p>  
 
-          <div className={classes.uploadButtonContainer}>
-
-            <div className={classes.uploadButtonWrapper}>
-              <Button
-                color='primary'
-                variant='outline'
-                size='small'
-                onClick={handleReject}
-              >
-                Choose File 
-              </Button>  
-            </div>
-
-            <div className={classes.fileChosenTextWrapper}>
-              <span>No file chosen</span> 
-            </div>
-            
-          </div>
-          
-
-          <p className={classes.warningUpdateText}>
-              Maskinporten krever at du oppdaterer JWK hver 12. måned.
-              Hvis JWK ikke oppdateres vil integrasjonen slutte å virke.
-          </p>
-
-          <div className={classes.buttonContainer}>
-
-            <div className={classes.cancelButton}>
-              <Button
-                color='primary'
-                variant='outline'
-                size='small'
-                onClick={handleReject}
-              >
-                Avbryt 
-              </Button> 
-            </div>
-
-            <div className={classes.confirmButton}>
-              <Button
-                color='primary'
-                size='small'
-                onClick={handleConfirm}
-              >
-                Opprett 
-              </Button> 
-            </div>
-
-          </div>
-          
-        </div>
-
-              
+          <UploadComponent opprettKnappBlokkert={opprettKnappBlokkert} />
+        </div>    
       </div>
     </div>
   );

--- a/frontend/src/features/maskinportenIntAdm/UploadComponent.module.css
+++ b/frontend/src/features/maskinportenIntAdm/UploadComponent.module.css
@@ -1,0 +1,43 @@
+
+
+.gjemInputButton {
+  display: none;
+}
+
+.uploadButtonContainer {
+  display: flex;
+  margin-top: 10px;
+  align-items: center;
+}
+
+.uploadButtonWrapper {
+  margin-right: 10px;
+}
+
+
+.fileChosenTextWrapper {
+  font-size: 16px;
+}
+
+.warningUpdateText {
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 2rem;
+}
+
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
+.cancelButton {
+  margin: 10px;
+  display: flex;
+}
+
+.confirmButton {
+  margin: 10px;
+  display: flex;
+}

--- a/frontend/src/features/maskinportenIntAdm/UploadComponent.tsx
+++ b/frontend/src/features/maskinportenIntAdm/UploadComponent.tsx
@@ -1,0 +1,172 @@
+import React, { useState, useRef } from 'react';
+import axios from 'axios';
+import classes from './UploadComponent.module.css';
+import { Button } from '@digdir/design-system-react';
+// import { UploadIcon } from '@navikt/aksel-icons';
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { bekreftJwkTilgjengelighet, clearStateAfterApi } from '@/rtk/features/maskinportenPage/maskinportenPageSlice';
+import { useNavigate, Link } from 'react-router-dom';
+import { AuthenticationPath } from '@/routes/paths';
+
+    // FIX-ME: om fil er lastet opp, og bruker navigerer
+    // til annen side, og kommer tilbake: ER FIKSET
+
+export interface IUploadComponentProps {
+    opprettKnappBlokkert:boolean;
+}
+
+export const UploadComponent = ({opprettKnappBlokkert}:IUploadComponentProps) => {
+
+  const navigate = useNavigate();
+  const [upLoadedFile, setUpLoadedFile] = useState(); // fix-me: ikke helt stabil løsning
+
+  const [apiUploading, setApiUploading] = useState(false); 
+  const [errorText, setErrorText] = useState('');
+
+  const dispatch = useAppDispatch(); 
+  const reduxNavn = useAppSelector((state) => state.maskinportenPage.navn);
+  const reduxBeskrivelse = useAppSelector((state) => state.maskinportenPage.beskrivelse);
+  
+
+  const inputRefSkjultKnapp = useRef(null);
+    
+  // <input type="file"> gir en stygg upload-knapp, som er skjult
+  // her brukes useRef() til å aktivere fil-opplasting
+  const handleKlikkSynligKnapp = () => {
+    if (inputRefSkjultKnapp) {
+        inputRefSkjultKnapp?.current?.click();    
+    }  
+  }
+
+  const handleOnChangeFilOpplastet = (event: any) => {
+    setUpLoadedFile(event.target.files[0]);
+
+    if (event.target.files[0]) {
+        dispatch(bekreftJwkTilgjengelighet( { onJwkFileAvailable: true} ));
+    } else {
+        dispatch(bekreftJwkTilgjengelighet( { onJwkFileAvailable: false} ));
+        // console.log("Blir faktisk kallet ved onCancel her...")
+    }  
+  };
+
+  // gir template string fil-beskrivelse til bruker om filen er oppe i browser
+  const filbeskrivelse = () => {
+    if (upLoadedFile) {
+      return `Fil opplastet er ${ upLoadedFile.name}, størrelse er ${ upLoadedFile.size} bytes.`
+    } else {   
+       return `Ingen fil opplastet ennå (maks er 64 kB).`; 
+    } 
+  } 
+
+  if (!opprettKnappBlokkert && !upLoadedFile) {
+    // if navigation by user has Redux and upLoad out of sync, Redux is cleared
+    dispatch(clearStateAfterApi()); 
+  }
+
+  // Går tilbake til startsiden om bruker trykker Avbryt
+  const handleAvbryt = () => {
+    // om man trykker Avbryt etter å ha lastet opp fil, må Redux også tømmes OK
+    dispatch(clearStateAfterApi());
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  }
+
+  // sender fil til BFF om bruker trykker Opprett
+  const handleApiUpload = (formData: FormData) => {
+    console.log("Er i handleApiUpload");
+    setApiUploading(true); // fix-me: informasjon ikke brukt ennå
+    axios
+      .post('/authfront/api/v1/systemuser/uploaddisk', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      })
+      .then((response) => {
+        if (response) {
+          setErrorText('');
+        }
+      })
+      .catch((error) => {
+        if (error) {
+          setErrorText('Noe gikk galt i opplasting til BFF');
+        }
+      })
+      .finally( () => {
+        setApiUploading(false); // fix-me: informasjon ikke brukt ennå
+      });
+  };
+
+  // skal bare kjøres om "Opprett" knapp er blitt aktivert
+  // og upLoadedFile er tilgjengelig
+  const handleOpprettKnappTrykket = () => {
+    if (upLoadedFile) {
+      const formData = new FormData();
+      formData.append('file', upLoadedFile, upLoadedFile.name);
+      formData.append("navn", reduxNavn);
+      formData.append("beskrivelse", reduxBeskrivelse);
+      handleApiUpload(formData);
+    }
+    // Tømmer Redux
+    dispatch(clearStateAfterApi());
+    // Navigerer så til Hovedside: burde oppdatere Redux også
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  }
+
+
+  return (
+    <div>
+        <div className={classes.uploadButtonContainer}>
+            <div className={classes.uploadButtonWrapper}>
+                <input 
+                    type='file'
+                    accept='.jwk'
+                    id = 'skjultKnapp'
+                    className = {classes.gjemInputButton}
+                    ref={inputRefSkjultKnapp}
+                    onChange={ handleOnChangeFilOpplastet }
+                />
+                <Button 
+                    id= 'synligKnapp'
+                    color='primary'
+                    variant='outline' 
+                    size='small'
+                    onClick = { handleKlikkSynligKnapp }
+                >
+                    Last opp fil.jwk
+                </Button> 
+            </div>
+            <div className={classes.fileChosenTextWrapper}>
+              <span>{filbeskrivelse()}</span> 
+            </div> 
+        </div>
+
+        <p className={classes.warningUpdateText}>
+              Maskinporten krever at du oppdaterer JWK hver 12. måned.
+              Hvis JWK ikke oppdateres vil integrasjonen slutte å virke.
+        </p>
+
+        <div className={classes.buttonContainer}>
+          <div className={classes.cancelButton}>
+            <Button
+              color='primary'
+              variant='outline'
+              size='small'
+              onClick={handleAvbryt}
+            >
+              Avbryt 
+            </Button> 
+          </div>
+
+          <div className={classes.confirmButton}>
+            <Button
+              color='primary'
+              size='small'
+              onClick={handleOpprettKnappTrykket}
+              disabled={opprettKnappBlokkert}
+            >
+              Opprett
+            </Button> 
+          </div>
+      </div>  
+    </div>      
+  );
+};

--- a/frontend/src/features/maskinportenIntAdm/UploadComponent.tsx
+++ b/frontend/src/features/maskinportenIntAdm/UploadComponent.tsx
@@ -70,12 +70,13 @@ export const UploadComponent = ({opprettKnappBlokkert}:IUploadComponentProps) =>
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
-  // sender fil til BFF om bruker trykker Opprett
+  // sender fil til BFF om bruker trykker Opprett:
+  // /authfront/api/v1/systemuser/uploaddisk
+  // tester 20.10.23 ny URL: /uploadjwk
   const handleApiUpload = (formData: FormData) => {
-    console.log("Er i handleApiUpload");
     setApiUploading(true); // fix-me: informasjon ikke brukt ennå
     axios
-      .post('/authfront/api/v1/systemuser/uploaddisk', formData, {
+      .post('/authfront/api/v1/systemuser/uploadjwk', formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },

--- a/frontend/src/features/maskinportenIntAdm/XSDUpload.tsx
+++ b/frontend/src/features/maskinportenIntAdm/XSDUpload.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+// import { AltinnSpinner, FileSelector } from 'app-shared/components';
+import { Spinner } from '@digdir/design-system-react';
+import FileSelector from './FileSelector';
+import axios from 'axios';
+// import ErrorPopover from 'app-shared/components/ErrorPopover';
+// import { datamodelsUploadPath } from 'app-shared/api/paths';
+// import { useTranslation } from 'react-i18next';
+
+// import { useQueryClient } from '@tanstack/react-query';
+// import { QueryKey } from 'app-shared/types/QueryKey';
+// import { useStudioUrlParams } from 'app-shared/hooks/useStudioUrlParams';
+
+export interface IXSDUploadProps {
+  disabled?: boolean;
+  submitButtonRenderer?: (fileInputClickHandler: (event: any) => void) => JSX.Element;
+}
+
+export const XSDUpload = ({
+  disabled,
+  submitButtonRenderer,
+}: IXSDUploadProps) => {
+  // const { t } = useTranslation();
+  // const { org, app } = useStudioUrlParams();
+  // const queryClient = useQueryClient();
+
+  const [uploading, setUploading] = React.useState(false);
+  const [errorText, setErrorText] = React.useState('');
+
+  const uploadButton = React.useRef(null);
+
+  const handleUpload = (formData: FormData) => {
+    setUploading(true);
+    axios
+      .post('/authfront/api/v1/systemuser/uploaddisk', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      })
+      .then((response) => {
+        if (response) {
+          setErrorText('');
+        }
+      })
+      .catch((error) => {
+        if (error) {
+          setErrorText('Noe gikk galt i opplasting til BFF');
+        }
+      })
+      .finally( () => {
+        setUploading(false);
+      });
+  };
+
+  return (
+    <>
+      <span ref={uploadButton}>
+        {uploading ? (
+          <Spinner title={'Laster opp .jwk'} />
+        ) : (
+          <FileSelector
+            busy={false}
+            submitHandler={handleUpload}
+            accept='.jwk'
+            formFileName='file'
+            submitButtonRenderer={submitButtonRenderer}
+            disabled={disabled}
+          />
+        )}
+      </span>
+      {errorText && (
+        <p>{errorText}</p>
+      )}
+    </>
+  );
+};

--- a/frontend/src/rtk/features/maskinportenPage/maskinportenPageSlice.ts
+++ b/frontend/src/rtk/features/maskinportenPage/maskinportenPageSlice.ts
@@ -2,12 +2,14 @@ import { createSlice } from '@reduxjs/toolkit';
 
 export interface SliceState {
   navn: string;
-beskrivelse: string;
+  beskrivelse: string;
+  onJwkFileAvailable: boolean
 }
 
 const initialState: SliceState = {
     navn: '',
     beskrivelse: '', 
+    onJwkFileAvailable: false,
 };
 
 // foreløpig lagreNavnBeskrivelseKnapp skal senere gi API POST kall til BFF
@@ -17,12 +19,22 @@ const maskinportenPageSlice = createSlice({
   name: 'maskinporten',
   initialState,
   reducers: {
-    lagreNavnBeskrivelseKnapp : (state, action) => {
+    lagreNavn : (state, action) => {
         state.navn = action.payload.navn;
-        state.beskrivelse = action.payload.beskrivelse;
-    }
+    },
+    lagreBeskrivelse : (state, action) => {
+      state.beskrivelse = action.payload.beskrivelse;
+    },
+    bekreftJwkTilgjengelighet : (state, action) => {
+      state.onJwkFileAvailable = action.payload.onJwkFileAvailable;
+    },
+    clearStateAfterApi : (state) => {
+      state.navn = '';
+      state.beskrivelse = '';
+      state.onJwkFileAvailable = false;
+    },
   },
 });
 
 export default maskinportenPageSlice.reducer;
-export const { lagreNavnBeskrivelseKnapp } = maskinportenPageSlice.actions;
+export const { lagreNavn, lagreBeskrivelse, bekreftJwkTilgjengelighet, clearStateAfterApi } = maskinportenPageSlice.actions;


### PR DESCRIPTION
## Description
We are trying to connect frontend to the new /uploadjwk endpoint.

The old endpoint /uploaddisk
accepts a Form-object, with form

file: binary,
navn: navn9,
beskrivelse: besk9

but the new endpoint responds with 400 Bad Request.

We are trying to debug this issue on the BFF.

## Related Issue(s)
- #8 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green


