### PR TITLE
OverviewPage redux slice setup and first GET API call

### DIFF
--- a/frontend/src/features/overviewpage/OverviewPage.tsx
+++ b/frontend/src/features/overviewpage/OverviewPage.tsx
@@ -1,15 +1,31 @@
-import { useTranslation } from 'react-i18next';
-import * as React from 'react';
 
+import * as React from 'react';
+import { useEffect } from 'react';
 import { Page, PageHeader, PageContent, PageContainer } from '@/components';
+import { OverviewPageContent } from './OverviewPageContent';
 import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
 import { useMediaQuery } from '@/resources/hooks';
+import { useTranslation } from 'react-i18next';
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { fetchOverviewPage } from '@/rtk/features/overviewPage/overviewPageSlice';
 
-import { OverviewPageContent } from './OverviewPageContent';
 
 export const OverviewPage = () => {
   const { t } = useTranslation('common'); // Fix-me: skift til auth-språknøkkel
   const isSm = useMediaQuery('(max-width: 768px)');
+  const dispatch = useAppDispatch();
+
+  // Tester ny Redux overviewPageSlice her, med kode fra UserInfoBar.tsx
+  // UserInfo er jo bare lastet inn en gang, men igjen om ikke tilstede ved re-rendering
+  const overviewLoaded = useAppSelector((state) => state.overviewPage.overviewLoaded);
+ 
+  // må finne mer elegang måte å gjøre dette på: og dynamisk: vil bare laste 1 gang tror jeg
+  useEffect(() => {
+    if (!overviewLoaded) {
+      console.log("Prøver laste inn overviewPage data til Redux");
+      void dispatch(fetchOverviewPage());
+    }
+  }, []);
 
   return (
     <PageContainer>

--- a/frontend/src/rtk/app/store.ts
+++ b/frontend/src/rtk/app/store.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
 import userInfoReducer from '../features/userInfo/userInfoSlice';
+import overviewPageReducer from '../features/overviewPage/overviewPageSlice';
 import creationPageReducer from '../features/creationPage/creationPageSlice';
 import maskinportenPageReducer from '../features/maskinportenPage/maskinportenPageSlice';
 
@@ -11,6 +12,7 @@ const store = import.meta.env.PROD
   ? configureStore({
       reducer: {
         userInfo: userInfoReducer,
+        overviewPage: overviewPageReducer,
         creationPage: creationPageReducer,
         maskinportenPage: maskinportenPageReducer,
       },
@@ -18,6 +20,7 @@ const store = import.meta.env.PROD
   : configureStore({
       reducer: {
         userInfo: userInfoReducer,
+        overviewPage: overviewPageReducer,
         creationPage: creationPageReducer,
         maskinportenPage: maskinportenPageReducer,
       },

--- a/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
+++ b/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
@@ -11,6 +11,8 @@ import axios from 'axios';
 // based on userInfoSlice code and array code from 
 // delegableApiSlice.ts AccMan repo
 
+
+
 export interface SystemUserObject {
     id: string;
     title: string;
@@ -21,6 +23,8 @@ export interface SystemUserObject {
   }
 // FIX-ME: tror key:value par created:Date; med fordel kan legges til senere
 // det er lettere med en ren String-array i første omgang
+// FIX-ME2: objects received from BFF GET /systemuser/0 
+// does not contain "ownedBy" nor "controlledBy"
  
 export interface SliceState {
   systemUserArray: SystemUserObject[];

--- a/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
+++ b/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
@@ -3,11 +3,13 @@ import axios from 'axios';
 
 // import { getCookie } from '@/resources/Cookie/CookieMethods';
 
+// new overviewPageSlice
 // will reflect API call to Swagger GET /systemuser/{id}
 // but also Runes new SystemUserObject (see Wiki update 23.10.23)
 // The OverviewPage has a list of SystemUserObjects
-// ---> array in Slice?
-// ---> type the SystemUserObject?!
+
+// based on userInfoSlice code and array code from 
+// delegableApiSlice.ts AccMan repo
 
 export interface SystemUserObject {
     id: string;
@@ -17,7 +19,7 @@ export interface SystemUserObject {
     ownedBy: string;
     controlledBy: string;
   }
-// tror key:value par created:Date; med fordel kan legges til senere
+// FIX-ME: tror key:value par created:Date; med fordel kan legges til senere
 // det er lettere med en ren String-array i første omgang
  
 export interface SliceState {
@@ -70,7 +72,7 @@ const overviewPageSlice = createSlice({
             };
             downLoadedArray.push(loopObject);
         }
-        
+
         state.systemUserArray = downLoadedArray;
         state.overviewLoaded = true;
       })

--- a/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
+++ b/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
@@ -1,0 +1,83 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+// import { getCookie } from '@/resources/Cookie/CookieMethods';
+
+// will reflect API call to Swagger GET /systemuser/{id}
+// but also Runes new SystemUserObject (see Wiki update 23.10.23)
+// The OverviewPage has a list of SystemUserObjects
+// ---> array in Slice?
+// ---> type the SystemUserObject?!
+
+export interface SystemUserObject {
+    id: string;
+    title: string;
+    description: string;
+    systemType: string;
+    ownedBy: string;
+    controlledBy: string;
+  }
+// tror key:value par created:Date; med fordel kan legges til senere
+// det er lettere med en ren String-array i første omgang
+ 
+export interface SliceState {
+  systemUserArray: SystemUserObject[];
+  overviewLoaded: boolean;
+  overviewError: string;
+}
+
+const initialState: SliceState = {
+    systemUserArray: [],
+    overviewLoaded: false,
+    overviewError: '',
+};
+
+// URL er hardkodet til GET "0" i Swagger ---> fix-me senere
+export const fetchOverviewPage = createAsyncThunk('overview/fetchOverviewPageSlice', async () => {
+  return await axios
+    .get('/authfront/api/v1/systemuser/0')
+    .then((response) => response.data)
+    .catch((error) => {
+      console.error(error);
+      throw new Error(String(error.response.data));
+    });
+});
+
+const overviewPageSlice = createSlice({
+  name: 'overview',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchOverviewPage.fulfilled, (state, action) => {
+        const dataArray = action.payload;
+        const downLoadedArray: SystemUserObject[] = [];
+
+        for (let i = 0; i < dataArray.length; i++) {
+            const id = dataArray[i].id;
+            const title = dataArray[i].title;
+            const description = dataArray[i].description;
+            const systemType = dataArray[i].systemType;
+            const ownedBy = dataArray[i].ownedBy;
+            const controlledBy = dataArray[i].controlledBy;
+            const loopObject = {
+                id,
+                title,
+                description,
+                systemType,
+                ownedBy,
+                controlledBy,
+            };
+            downLoadedArray.push(loopObject);
+        }
+        
+        state.systemUserArray = downLoadedArray;
+        state.overviewLoaded = true;
+      })
+      .addCase(fetchOverviewPage.rejected, (state, action) => {
+        state.overviewError = action.error.message ?? 'Unknown error';
+      })
+  },
+});
+
+export default overviewPageSlice.reducer;


### PR DESCRIPTION
## Description
The OverviewPage should present a list of SystemUsers.

In order to do this the list of SystemUserObjects must be downloaded
from BFF, and stored in Redux State.

This issue addresses these aims.

However, the Swagger API still reflect an outdated version of 
the SystemUserObject, so more modifications must be made.

The API call is robust enough to tolerate the outdated object.


## Related Issue(s)
- #71 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

