### PR TITLE
CreationPage now posts real values to BFF

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -3,78 +3,58 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
-
-import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-// import { lagreOpprettKnapp } from '@/rtk/features/creationPage/creationPageSlice';
+import { useAppDispatch } from '@/rtk/app/hooks';
 import { postNewSystemUser, CreationRequest } from '@/rtk/features/creationPage/creationPageSlice';
-
 import { TextField, Button, Select } from '@digdir/design-system-react';
 import classes from './CreationPageContent.module.css';
 import { useMediaQuery } from '@/resources/hooks';
 
 
-
 export const CreationPageContent = () => {
   
-  // State variabler for input-bokser:
-  const [navn, setNavn] = useState('');
-  const [beskrivelse, setBeskrivelse] = useState('');
-
-  // State variabel for nedtrekksmeny:
-  const [selected, setSelected] = useState(''); 
+  // Local State variables for input-boxes and Nedtrekksmeny:
+  const [integrationName, setIntegrationName] = useState('');
+  const [descriptionEntered, setDescriptionEntered] = useState('');
+  const [selectedSystemType, setSelectedSystemType] = useState(''); 
 
   const { t } = useTranslation('common');
   const navigate = useNavigate();
-
-  const dispatch = useAppDispatch(); // fix-me: bygger kobling til REDUX 
-  const reduxNavn = useAppSelector((state) => state.creationPage.navn);
-  const reduxBeskrivelse = useAppSelector((state) => state.creationPage.beskrivelse);
+  const dispatch = useAppDispatch(); 
   
-
   // brukes i h2, ikke vist i Small/mobile view
   const isSm = useMediaQuery('(max-width: 768px)'); // fix-me: trengs denne?
   let overviewText: string;
   overviewText = 'Knytt systembruker til systemleverandør'; 
 
-
-  // skal nå bare gå tilbake til OverviewPage
   const handleReject = () => {
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
-  // Opprett-knapp flytter foreløpig bare 
-  // local State for Navn, Beskrivelse og Valgt Systemleverandør
-  // til Redux State, som er stabil så lenge app kjører
-  // ---> tilgjengelig også fra andre sider
-  // ---> API er ennå ikke tilgjengelig per 10.10.23
-
-  // 25.10.23: handleConfirm skal oppdateres med POST i Slice
   const handleConfirm = () => {
-
-    // tester selve kallet først:
+    // POST 3 useState variables, while the last two not yet implemented
     const PostObjekt: CreationRequest = {
-      integrationTitle: "test1",
-      description: "test2",
-      selectedSystemType: "test3",
-      clientId: "test4",
-      ownedByPartyId: "test5"
+      integrationTitle: integrationName,
+      description: descriptionEntered,
+      selectedSystemType: selectedSystemType,
+      clientId: "notImplemented",
+      ownedByPartyId: "notImplemented"
     };
 
-    void dispatch(postNewSystemUser(PostObjekt)); // generell form... må gi input objekt 
-    // med navn, beskrivelse... etc... type CreationRequest: bare test-verdier ennå
+    void dispatch(postNewSystemUser(PostObjekt));  
     
-    // gammel dispatch skal ikke brukes
-    // dispatch(lagreOpprettKnapp( { navn: navn, beskrivelse: beskrivelse, selected: selected } ));
-    setNavn('');
-    setBeskrivelse('');
-    setSelected('');
-    // navigasjon til OverviewPage skal vise med ny GET request den nye SystemBruker
-    // ettersom vi ikke har noen annen suksess-melding ennå
+    // Clean up local State variables before returning to main page
+    setIntegrationName('');
+    setDescriptionEntered('');
+    setSelectedSystemType('');
+
+    // NB! navigasjon til OverviewPage skal vise med ny GET request den nye SystemBruker
+    // ettersom vi ikke har noen annen suksess-melding ennå:
+    // Men vi har creationPageSlice status "posted" nå... men den virker bare først gang
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
 
-
+  // MOCK VALUES for NedtrekksMeny: List of Firms/Products not available from BFF yet
   // options med label skilt fra value (samme verdi for demo)
   // use inline interface definition for Type her
   // https://stackoverflow.com/questions/35435042/how-can-i-define-an-array-of-objects
@@ -123,33 +103,24 @@ export const CreationPageContent = () => {
   
   // Håndterer skifte av valgmuligheter (options) i Nedtrekksmeny
   const handleChangeInput = (val: string) => {
-    setSelected(val);
+    setSelectedSystemType(val);
   };
-  // const minInputId:string = "inputIdString"; // valg id trengs ikke?
-
-  // Dette er mest for knapper og videre navigering,
-  // mens her er <Link> kanskje bedre: fra Studio Dashboard
-  // men bør også sjekke Designsystemet om de har noe på gang der
-  const handleSkiftTilCustomCreationPage = () => {
-    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.CustomCreation);
-  };
- 
  
   return (
     <div className={classes.creationPageContainer}>
       <div className={classes.inputContainer}> 
         <div className={classes.nameWrapper}>
             <TextField 
-              label = 'Navn'
-              value = { navn }
-              onChange={e => setNavn(e.target.value)}
+              label = 'Integrasjonsnavn'
+              value = { integrationName }
+              onChange={e => setIntegrationName(e.target.value)}
             />
         </div>
         <div className={classes.descriptionWrapper}>
             <TextField 
               label= 'Beskrivelse' 
-              value = { beskrivelse }
-              onChange={e => setBeskrivelse(e.target.value)}
+              value = { descriptionEntered }
+              onChange={e => setDescriptionEntered(e.target.value)}
             />
         </div>
       </div>
@@ -166,7 +137,6 @@ export const CreationPageContent = () => {
             vurdering av disse.
       </p>
 
-
       <div className={classes.flexContainer}>
         <div className={classes.leftContainer}>
           <div className={classes.selectWrapper}>
@@ -174,7 +144,7 @@ export const CreationPageContent = () => {
               label="Velg systemleverandør og system"
               options={testoptions}
               onChange={handleChangeInput}
-              value={selected}
+              value={selectedSystemType}
             />
           </div>
         </div>

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -5,7 +5,8 @@ import { useNavigate, Link } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
 
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { lagreOpprettKnapp } from '@/rtk/features/creationPage/creationPageSlice';
+// import { lagreOpprettKnapp } from '@/rtk/features/creationPage/creationPageSlice';
+import { postNewSystemUser, CreationRequest } from '@/rtk/features/creationPage/creationPageSlice';
 
 import { TextField, Button, Select } from '@digdir/design-system-react';
 import classes from './CreationPageContent.module.css';
@@ -28,6 +29,7 @@ export const CreationPageContent = () => {
   const dispatch = useAppDispatch(); // fix-me: bygger kobling til REDUX 
   const reduxNavn = useAppSelector((state) => state.creationPage.navn);
   const reduxBeskrivelse = useAppSelector((state) => state.creationPage.beskrivelse);
+  
 
   // brukes i h2, ikke vist i Small/mobile view
   const isSm = useMediaQuery('(max-width: 768px)'); // fix-me: trengs denne?
@@ -45,11 +47,29 @@ export const CreationPageContent = () => {
   // til Redux State, som er stabil så lenge app kjører
   // ---> tilgjengelig også fra andre sider
   // ---> API er ennå ikke tilgjengelig per 10.10.23
+
+  // 25.10.23: handleConfirm skal oppdateres med POST i Slice
   const handleConfirm = () => {
-    dispatch(lagreOpprettKnapp( { navn: navn, beskrivelse: beskrivelse, selected: selected } ));
+
+    // tester selve kallet først:
+    const PostObjekt: CreationRequest = {
+      integrationTitle: "test1",
+      description: "test2",
+      selectedSystemType: "test3",
+      clientId: "test4",
+      ownedByPartyId: "test5"
+    };
+
+    void dispatch(postNewSystemUser(PostObjekt)); // generell form... må gi input objekt 
+    // med navn, beskrivelse... etc... type CreationRequest: bare test-verdier ennå
+    
+    // gammel dispatch skal ikke brukes
+    // dispatch(lagreOpprettKnapp( { navn: navn, beskrivelse: beskrivelse, selected: selected } ));
     setNavn('');
     setBeskrivelse('');
     setSelected('');
+    // navigasjon til OverviewPage skal vise med ny GET request den nye SystemBruker
+    // ettersom vi ikke har noen annen suksess-melding ennå
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -1,11 +1,10 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
-// FIX-ME: må omskrives slik at navn, beskrivelse og selected
+// FIX-ME: muligens omskrives slik at navn, beskrivelse og selected
 // blir tilgjengelig/dispatch i det fokus mistes, a la MaskinportenPage
-// ---> Opprett-knapp bør også inaktiveres til de 3 datapunktene er klare
-
-// slik det er i dag så er det en knapp som flytter data til Redux...
+// Foreløpig er det useState Local State som bærer de 3 tilgjengelige verdiene
+// som blir sendt til BFF
 
 export interface SliceState {
   navn: string;
@@ -47,18 +46,11 @@ export const postNewSystemUser = createAsyncThunk('creationPageSlice/postNewSyst
     });
 });
 
-// foreløpig lagreOpprettKnapp skal fjernes
-// vi satser nå på dispatch ved onBlur (a la maskinPortenPage)
+
 const creationPageSlice = createSlice({
   name: 'creation',
   initialState,
-  reducers: {
-    lagreOpprettKnapp : (state, action) => {
-        state.navn = action.payload.navn;
-        state.beskrivelse = action.payload.beskrivelse;
-        state.selected = action.payload.selected;
-    }
-  },
+  reducers: {},
   extraReducers: (builder) => {
     builder
       .addCase(postNewSystemUser.fulfilled, (state) => {
@@ -71,4 +63,3 @@ const creationPageSlice = createSlice({
 });
 
 export default creationPageSlice.reducer;
-export const { lagreOpprettKnapp } = creationPageSlice.actions;

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -7,18 +7,12 @@ import axios from 'axios';
 // som blir sendt til BFF
 
 export interface SliceState {
-  navn: string;
-  beskrivelse: string;
-  selected: string;
-  posted: boolean;
+  postConfirmed: boolean;
   creationError: string;
 }
 
 const initialState: SliceState = {
-    navn: '',
-    beskrivelse: '', 
-    selected: '',
-    posted: false,
+    postConfirmed: false,
     creationError: '',
 };
 
@@ -32,9 +26,7 @@ export interface CreationRequest {
 }
 
 // OK let the CreationPage populate the systemUserInfo object,
-// and just accept the object as input here and post it on to BFF
-// seems to work: that is, the POST goes through, and the GET list
-// shows another member in list, but the attributes are "test1", "test2" etc... OK
+// and just accept the object as input here and post parameter on to BFF
 export const postNewSystemUser = createAsyncThunk('creationPageSlice/postNewSystemUser', 
   async (systemUserInfo: CreationRequest) => {
   return await axios
@@ -54,7 +46,7 @@ const creationPageSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(postNewSystemUser.fulfilled, (state) => {
-        state.posted = true;
+        state.postConfirmed = true;
       })
       .addCase(postNewSystemUser.rejected, (state, action) => {
         state.creationError = action.error.message ?? 'Unknown error';

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -1,18 +1,54 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+// FIX-ME: må omskrives slik at navn, beskrivelse og selected
+// blir tilgjengelig/dispatch i det fokus mistes, a la MaskinportenPage
+// ---> Opprett-knapp bør også inaktiveres til de 3 datapunktene er klare
+
+// slik det er i dag så er det en knapp som flytter data til Redux...
 
 export interface SliceState {
-    navn: string;
+  navn: string;
   beskrivelse: string;
   selected: string;
+  posted: boolean;
+  creationError: string;
 }
 
 const initialState: SliceState = {
     navn: '',
     beskrivelse: '', 
     selected: '',
+    posted: false,
+    creationError: '',
 };
 
-// foreløpig lagreOpprettKnapp skal senere gi API POST kall til BFF
+// CreationShape form is based on Swagger POST description per 25.10.23
+export interface CreationRequest {
+  integrationTitle: string,
+  description: string,
+  selectedSystemType: string,
+  clientId: string,
+  ownedByPartyId: string
+}
+
+// OK let the CreationPage populate the systemUserInfo object,
+// and just accept the object as input here and post it on to BFF
+// seems to work: that is, the POST goes through, and the GET list
+// shows another member in list, but the attributes are "test1", "test2" etc... OK
+export const postNewSystemUser = createAsyncThunk('creationPageSlice/postNewSystemUser', 
+  async (systemUserInfo: CreationRequest) => {
+  return await axios
+    .post('/authfront/api/v1/systemuser', systemUserInfo)
+    .then((response) => response.data)
+    .catch((error) => {
+      console.error(error);
+      throw new Error(String(error.response.data));
+    });
+});
+
+// foreløpig lagreOpprettKnapp skal fjernes
+// vi satser nå på dispatch ved onBlur (a la maskinPortenPage)
 const creationPageSlice = createSlice({
   name: 'creation',
   initialState,
@@ -22,6 +58,15 @@ const creationPageSlice = createSlice({
         state.beskrivelse = action.payload.beskrivelse;
         state.selected = action.payload.selected;
     }
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(postNewSystemUser.fulfilled, (state) => {
+        state.posted = true;
+      })
+      .addCase(postNewSystemUser.rejected, (state, action) => {
+        state.creationError = action.error.message ?? 'Unknown error';
+      })
   },
 });
 

--- a/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
+++ b/frontend/src/rtk/features/overviewPage/overviewPageSlice.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 
 
 // Ny standard SystemUserObjectsDTO fra Swagger 25.10.23
+// Se også issue 23 for ny form på objekt
 
 export interface SystemUserObjectDTO {
     id: string;
@@ -18,6 +19,9 @@ export interface SystemUserObjectDTO {
   }
 // FIX-ME: tror key:value par created:Date; med fordel kan legges til senere
 // det er lettere med en ren String-array i første omgang
+
+// FIX-ME: "supplierOrgno" er feilformet, skal egentlig være "supplierOrgNo"
+// i følge issue 23: kommenterte dette review i dag
 
  
 export interface SliceState {


### PR DESCRIPTION
## Description
So far the CreationPage only mock-posted the integrationName, the description and selectedSystemType to OverviewPage via Redux State.

Now the 3 available values (clientId and ownedByPartyId not implemented yet),
are posted to BFF endpoint /authfront/api/v1/systemuser

The new SystemUser can then be seen in the OverviewPage list (after hard reload,
the dynamic GET list is not implemented yet).


## Related Issue(s)
- #77 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] User documentation is updated in Repo Wiki.
