### PR TITLE
Establish Cypress folders, config, and first End-to-End (E2E) tests 

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,39 +1,30 @@
 # The Cypress tests for altinn-authentication-frontend
 This is the working folder for Cypress tests for the React frontend part of the new altinn-authentication-frontend.<br>
 
-// Branch er cypress1, som jeg skal sette opp ting på,
-// men lite av dette kommer inn i ferdig versjon vil jeg tro:
-// Noatater og kode på tidligere Cypress arbeid finnes:
-1) /repos/Cypress/
-2) /0_0_1_Programmering/Cypress_070823/
-3) /0_0_1_Programmering/DigDir_prosjekter/PluralSight...
 
-Jeg baserer meg først på gammel Cypress9 kode i 
-/repos/Cypress/Cypress-Fundamentals/
-der man har 3 kataloger, side-om-side,
-/api/, /app/ og /cypress/
-der api og app kjører sammen, 
-og så blir /cypress/ startet på utsiden, med 
-> npx et-eller-annet
-
-Tror jeg har noen notater på dette etter "npx" søk i /Cypress_070823/,
-ja notater av 03.08.23 er relevante for helt basale start-kommandoer.
-
-
-
-
-## How-to-use these Cypress tests 26.10.23 (this is a work in progress):
+## How-to-use Cypress tests per 30.10.23 (this is a work in progress):
 
 The React app should be up and running, along with the other 3 processes
 (BFF dotnet app, app-localtest dotnet app, app-localtest Docker loadbalancer/NginX etc, see README or Repo Wiki).
 
 
+<b>30.10.23:</b> The first Cypress End-to-end (E2E) test is ready at root in /cypress/
 
-### Links to new pages and paths in the new app
+Running Cypress tests requires that Docker and the 3 apps are running (see other README).
 
-The app should now be running in the Vite webserver,<br>
-and is pseudo-available at http://localhost:5173 
-(showing just a blue screen), <br>
+The Cypress version v13.3.3 should be installed. Briefly, start the Cypress Runneer by entering the /cypress/ folder and running the npx cypres open command: 
 
-(just yet the base-path to website is a bit unclear...)
+> cd cypress <br>
+> npx cypress open
+
+A Cypress window should open. You should click E2E Testing.<br>
+Then choose Electron browser, and run first test by clicking<br>
+test1.cy.js
+
+Then Cypress should log in via http://local.altinn.cloud/, <br>
+and go to http://local.altinn.cloud/authfront/ui/auth/overview
+
+If it is not working, the control test-file <br>
+spec.cy.js <br>
+should run as a control for the Cypress runner (goes to https://example.cypress.io )
 

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,0 +1,39 @@
+# The Cypress tests for altinn-authentication-frontend
+This is the working folder for Cypress tests for the React frontend part of the new altinn-authentication-frontend.<br>
+
+// Branch er cypress1, som jeg skal sette opp ting på,
+// men lite av dette kommer inn i ferdig versjon vil jeg tro:
+// Noatater og kode på tidligere Cypress arbeid finnes:
+1) /repos/Cypress/
+2) /0_0_1_Programmering/Cypress_070823/
+3) /0_0_1_Programmering/DigDir_prosjekter/PluralSight...
+
+Jeg baserer meg først på gammel Cypress9 kode i 
+/repos/Cypress/Cypress-Fundamentals/
+der man har 3 kataloger, side-om-side,
+/api/, /app/ og /cypress/
+der api og app kjører sammen, 
+og så blir /cypress/ startet på utsiden, med 
+> npx et-eller-annet
+
+Tror jeg har noen notater på dette etter "npx" søk i /Cypress_070823/,
+ja notater av 03.08.23 er relevante for helt basale start-kommandoer.
+
+
+
+
+## How-to-use these Cypress tests 26.10.23 (this is a work in progress):
+
+The React app should be up and running, along with the other 3 processes
+(BFF dotnet app, app-localtest dotnet app, app-localtest Docker loadbalancer/NginX etc, see README or Repo Wiki).
+
+
+
+### Links to new pages and paths in the new app
+
+The app should now be running in the Vite webserver,<br>
+and is pseudo-available at http://localhost:5173 
+(showing just a blue screen), <br>
+
+(just yet the base-path to website is a bit unclear...)
+

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+};

--- a/cypress/cypress/e2e/spec.cy.js
+++ b/cypress/cypress/e2e/spec.cy.js
@@ -1,0 +1,8 @@
+describe('template spec', () => {
+  
+  it('passes', () => {
+    cy.visit('https://example.cypress.io')
+  });
+  
+})
+

--- a/cypress/cypress/e2e/test1.cy.js
+++ b/cypress/cypress/e2e/test1.cy.js
@@ -1,0 +1,24 @@
+describe('template spec', () => {
+    /*
+    it('passes', () => {
+      cy.visit('https://example.cypress.io')
+    });
+    */
+  
+    // Dette virket, men bare i Electron, ikke i Chrome
+    it("passes", () => {
+      cy.visit('http://local.altinn.cloud/');
+  
+      cy.get("h1").contains("Welcome to Altinn App Local Testing");
+      cy.get("button").contains("Proceed to app").click();
+      cy.url().should("include", "/authfront/ui");
+      cy.visit("http://local.altinn.cloud/authfront/ui/auth/overview");
+    });
+  
+    /*
+    it('passes', () => {
+      cy.visit('http://local.altinn.cloud/authfront/ui/auth/overview')
+    });
+  
+    */
+  });

--- a/cypress/cypress/fixtures/example.json
+++ b/cypress/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/cypress/support/commands.js
+++ b/cypress/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/cypress/cypress/support/e2e.js
+++ b/cypress/cypress/support/e2e.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')


### PR DESCRIPTION
## Description
The first Cypress E2E tests have been configured in a new Cypress folder.

So far the tests must be run manually,
from the new Cypress folder,
with the npx cypress open command,
which require cypress 13.3.3 installation. 

The user should choose E2E testing
in the Cypress Runner window,
and also choose the build-in Electron browser,
as the Chrome browser is not set up or tested yet.

Clicking the first test, test1.cy.js,
should then login via the http://local.altinn.cloud/
and go to our main Overview page.

See further details  in the Wiki Repo and the new Cypress folder README.


## Related Issue(s)
- #87 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] User documentation is updated in Wiki Repo and Cypress folder README How-to-use description
