### PR TITLE
Implementation of new vendor fetch API in pull-down menu in CreationPage

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -11,12 +11,15 @@ import { useMediaQuery } from '@/resources/hooks';
 
 
 export const CreationPageContent = () => {
+
+  // Merk! Det er multiple design og datastruktur-valg som ikke er gjort ennå
+  // som påvirker denne siden: dette er annotert under hvert punkt
   
   // Local State variables for input-boxes and Nedtrekksmeny:
   const [integrationName, setIntegrationName] = useState('');
   const [descriptionEntered, setDescriptionEntered] = useState('');
   const [selectedSystemType, setSelectedSystemType] = useState('');
-  const [vendorsArrayPopulated, setVendorsArrayPopulated] = useState(false);
+  const [vendorsArrayPopulated, setVendorsArrayPopulated] = useState(false); // not used yet
 
   const { t } = useTranslation('common');
   const navigate = useNavigate();
@@ -57,7 +60,6 @@ export const CreationPageContent = () => {
 
   const systemRegisterVendorsArray = useAppSelector((state) => state.creationPage.systemRegisterVendorsArray);
 
-
   // MOCK VALUES for NedtrekksMeny: List of Firms/Products not available from BFF yet
   // options med label skilt fra value (samme verdi for demo)
   // use inline interface definition for Type her
@@ -68,21 +70,21 @@ export const CreationPageContent = () => {
   // "value er verdien som brukes av onChange-funksjonen.
   // label er teksten som vises i listen.""
 
-  
-
-
-  // Fix-me: Blir kjørt på hver render
-  // Mulig at Redux variabel systemRegisterVendorsLoaded kan brukes
-  // kombinert med en lokal useState-variabel
 
   // BUG: Redux blir tømt ved HardReload på CreationPage siden
-  // som gir tom liste her
+  // som gir semi-tom liste her: bare default testoptions dukker opp
+  // ---> dette skyldes at innlasting av Firma/Vendors nå blir
+  // bare gjort en eneste gang i OverviewPage
 
   // Også uklart hvordan/hvor "description" skal brukes
   // Skal den settes til "Beskrivelse"??
  
-  // Fix-Me: array for NedtrekksMeny verdier blir generert 
-  // multiple ganger om vi skal beholde 2 Mock verdier
+  // DEFAULT valg er TOMT OBJEKT: viss ikke vil øverste linje være
+  // f.eks. Visma, som da for brukeren synes å være et slags
+  // anbefalt valg ---> Altinn kan ikke anbefale firma slik...
+    // ---> mulig løsning er at TOMT OBJEKT blir lagt til i BFF
+  // TOMT OBJEKT er for at Designsystem Nedtrekksmeny ikke skal
+  // ha noe tomt øverst
 
   let testoptions: { label: string, value: string  }[] = [
     {
@@ -97,8 +99,9 @@ export const CreationPageContent = () => {
 
   const systemRegisterVendorsLoaded = useAppSelector((state) => state.creationPage.systemRegisterVendorsLoaded);
 
+  // NB! foreløpig løsning: bør gjøres til funksjonell komponent
   if (systemRegisterVendorsLoaded ) {
-    // console.log("Burde bygge vendorsArray bare en gang");
+    // console.log("Burde bygge vendorsArray bare en gang, men endelig design ikke klart.");
     
     for (let i = 0; i < systemRegisterVendorsArray.length; i++) {
       testoptions.push(
@@ -111,7 +114,6 @@ export const CreationPageContent = () => {
   };
 
 
-  
   // Håndterer skifte av valgmuligheter (options) i Nedtrekksmeny
   const handleChangeInput = (val: string) => {
     setSelectedSystemType(val);

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
-import { useAppDispatch } from '@/rtk/app/hooks';
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { postNewSystemUser, CreationRequest } from '@/rtk/features/creationPage/creationPageSlice';
 import { TextField, Button, Select } from '@digdir/design-system-react';
 import classes from './CreationPageContent.module.css';
@@ -15,7 +15,8 @@ export const CreationPageContent = () => {
   // Local State variables for input-boxes and Nedtrekksmeny:
   const [integrationName, setIntegrationName] = useState('');
   const [descriptionEntered, setDescriptionEntered] = useState('');
-  const [selectedSystemType, setSelectedSystemType] = useState(''); 
+  const [selectedSystemType, setSelectedSystemType] = useState('');
+  const [vendorsArrayPopulated, setVendorsArrayPopulated] = useState(false);
 
   const { t } = useTranslation('common');
   const navigate = useNavigate();
@@ -54,10 +55,35 @@ export const CreationPageContent = () => {
   }
 
 
+  const systemRegisterVendorsArray = useAppSelector((state) => state.creationPage.systemRegisterVendorsArray);
+
+
   // MOCK VALUES for NedtrekksMeny: List of Firms/Products not available from BFF yet
   // options med label skilt fra value (samme verdi for demo)
   // use inline interface definition for Type her
   // https://stackoverflow.com/questions/35435042/how-can-i-define-an-array-of-objects
+   
+  // merk at Storyboard dokumentasjon på Designsystemet
+  // skiller mellom "label" og "value"
+  // "value er verdien som brukes av onChange-funksjonen.
+  // label er teksten som vises i listen.""
+
+  
+
+
+  // Fix-me: Blir kjørt på hver render
+  // Mulig at Redux variabel systemRegisterVendorsLoaded kan brukes
+  // kombinert med en lokal useState-variabel
+
+  // BUG: Redux blir tømt ved HardReload på CreationPage siden
+  // som gir tom liste her
+
+  // Også uklart hvordan/hvor "description" skal brukes
+  // Skal den settes til "Beskrivelse"??
+ 
+  // Fix-Me: array for NedtrekksMeny verdier blir generert 
+  // multiple ganger om vi skal beholde 2 Mock verdier
+
   let testoptions: { label: string, value: string  }[] = [
     {
       "label": "",
@@ -67,38 +93,23 @@ export const CreationPageContent = () => {
       "label": "Visma AS (936796702): Visma Økonomi",
       "value": "Visma AS (936796702): Visma Økonomi"
     },
-    {
-      "label": "Visma AS (936796702): Visma HR",
-      "value": "Visma AS (936796702): Visma HR"
-    },
-    {
-      "label": "4Human AS (897757222): 4Human HRM",
-      "value": "4Human AS (897757222): 4Human HRM"
-    },
-    {
-      "label": "Aqua Group (931693670): Salmon King",
-      "value": "Aqua Group (931693670): Salmon King"
-    },
-    {
-      "label": "Snekkerbua ANS (92341234): Materialadmin",
-      "value": "Snekkerbua ANS (92341234): Materialadmin"
-    },
-    {
-      "label": "Vei og bil AS (9234523423): Prikk remover",
-      "value": "Vei og bil AS (9234523423): Prikk remover"
-    }
-  ]; // merk at Storyboard dokumentasjon på Designsystemet
-  // skiller mellom "label" og "value"
-  // "value er verdien som brukes av onChange-funksjonen.
-  // label er teksten som vises i listen.""
+  ];
 
-  // TextField er også importert fra Designsystemet,
-  // men selv om size="medium" er nevnt i første linje i Docs på Storyboard
-  // så er det ikke godtatt i importert TextField
-  // Faktisk er ikke TextField nevnt i Storyboard, men Textfield [SIC!]
-  // ---> Dokumentasjon er fortsatt ikke det helt store for Digdir...
-  // Nå er vel sikkert størrelse flyttet inn i CSS eller noe... 
-  // som igjen er gjemt i Figma Tokens... Herre!
+  const systemRegisterVendorsLoaded = useAppSelector((state) => state.creationPage.systemRegisterVendorsLoaded);
+
+  if (systemRegisterVendorsLoaded ) {
+    // console.log("Burde bygge vendorsArray bare en gang");
+    
+    for (let i = 0; i < systemRegisterVendorsArray.length; i++) {
+      testoptions.push(
+        {
+          label: `${systemRegisterVendorsArray[i].systemTypeId} : ${systemRegisterVendorsArray[i].systemVendor} `,
+          value: `${systemRegisterVendorsArray[i].systemTypeId} : ${systemRegisterVendorsArray[i].systemVendor} `  
+        }
+      );
+    };
+  };
+
 
   
   // Håndterer skifte av valgmuligheter (options) i Nedtrekksmeny

--- a/frontend/src/features/overviewpage/OverviewPage.tsx
+++ b/frontend/src/features/overviewpage/OverviewPage.tsx
@@ -8,6 +8,7 @@ import { useMediaQuery } from '@/resources/hooks';
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { fetchOverviewPage } from '@/rtk/features/overviewPage/overviewPageSlice';
+import { fetchSystemRegisterVendors } from '@/rtk/features/creationPage/creationPageSlice'; 
 
 
 export const OverviewPage = () => {
@@ -19,11 +20,13 @@ export const OverviewPage = () => {
   // UserInfo er jo bare lastet inn en gang, men igjen om ikke tilstede ved re-rendering
   const overviewLoaded = useAppSelector((state) => state.overviewPage.overviewLoaded);
  
+  // Fix-me: laster inn data bare en gang ved første render
   // må finne mer elegang måte å gjøre dette på: og dynamisk: vil bare laste 1 gang tror jeg
   useEffect(() => {
     if (!overviewLoaded) {
-      console.log("Prøver laste inn overviewPage data til Redux");
+      console.log("Prøver laste inn OverviewPage og CreationPage data til Redux");
       void dispatch(fetchOverviewPage());
+      void dispatch(fetchSystemRegisterVendors());
     }
   }, []);
 

--- a/frontend/src/features/overviewpage/OverviewPage.tsx
+++ b/frontend/src/features/overviewpage/OverviewPage.tsx
@@ -26,7 +26,7 @@ export const OverviewPage = () => {
     if (!overviewLoaded) {
       console.log("Prøver laste inn OverviewPage og CreationPage data til Redux");
       void dispatch(fetchOverviewPage());
-      void dispatch(fetchSystemRegisterVendors());
+      void dispatch(fetchSystemRegisterVendors()); // for CreationPage: see issue #94
     }
   }, []);
 

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -17,17 +17,7 @@ export const OverviewPageContent = () => {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
 
-  const dispatch = useAppDispatch(); // fix-me: bygger kobling til REDUX CreationPage
-  // for Runes Demo:
-  const reduxNavn = useAppSelector((state) => state.creationPage.navn);
-  const reduxBeskrivelse = useAppSelector((state) => state.creationPage.beskrivelse);
-  const reduxSelected = useAppSelector((state) => state.creationPage.selected);
-  
-  
-  // 24.10.23: Nytt SystemUserObject har nå 3 SUO i Redux
-  // Lager presentasjons-funksjon reduxCollectionBarArray
-  // der jeg stapper inn alle 6 feltene så får Rune og Mette 
-  // komme opp med et design
+  const dispatch = useAppDispatch();
   
   const reduxObjektArray = useAppSelector((state) => state.overviewPage.systemUserArray);
 

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -109,24 +109,6 @@ export const OverviewPageContent = () => {
         }
       />
 
-      <div>
-        <br></br>
-      </div>
-
-      { reduxNavn && (
-      <CollectionBar
-        title=  {reduxBeskrivelse}
-        subtitle= { reduxSelected }
-        additionalText= {reduxNavn}
-        color={'neutral'}
-        collection={[]}
-        compact={isSm}
-        proceedToPath={
-          '/fixpath/'
-        }
-      />
-      )}
-
     </div>
   );
 };

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -6,17 +6,29 @@ import axios from 'axios';
 // Foreløpig er det useState Local State som bærer de 3 tilgjengelige verdiene
 // som blir sendt til BFF
 
+export interface SystemRegisterObjectDTO {
+  systemTypeId: string;
+  systemVendor: string;
+  description: string;
+}
+
 export interface SliceState {
+  systemRegisterVendorsArray: SystemRegisterObjectDTO[];
+  systemRegisterVendorsLoaded: boolean;
+  systemRegisterError: string;
   postConfirmed: boolean;
   creationError: string;
 }
 
 const initialState: SliceState = {
+    systemRegisterVendorsArray: [],
+    systemRegisterVendorsLoaded: false,
+    systemRegisterError: '',
     postConfirmed: false,
     creationError: '',
 };
 
-// CreationShape form is based on Swagger POST description per 25.10.23
+// CreationRequest form is based on Swagger POST description per 25.10.23
 export interface CreationRequest {
   integrationTitle: string,
   description: string,
@@ -24,6 +36,17 @@ export interface CreationRequest {
   clientId: string,
   ownedByPartyId: string
 }
+
+export const fetchSystemRegisterVendors = createAsyncThunk('creation/fetchCreationPageSlice', async () => {
+  return await axios
+    .get('/authfront/api/v1/systemregister')
+    .then((response) => response.data)
+    .catch((error) => {
+      console.error(error);
+      throw new Error(String(error.response.data));
+    });
+});
+
 
 // OK let the CreationPage populate the systemUserInfo object,
 // and just accept the object as input here and post parameter on to BFF
@@ -45,6 +68,29 @@ const creationPageSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
+      .addCase(fetchSystemRegisterVendors.fulfilled, (state, action) => {
+        const dataArray = action.payload;
+        const downLoadedArray: SystemRegisterObjectDTO[] = [];
+
+        for (let i = 0; i < dataArray.length; i++) {
+          const systemTypeId = dataArray[i].systemTypeId;
+          const systemVendor = dataArray[i].systemVendor;
+          const description = dataArray[i].description;
+
+          const loopObject = {
+              systemTypeId,
+              systemVendor,
+              description,
+            };
+            downLoadedArray.push(loopObject);
+        }
+
+        state.systemRegisterVendorsArray = downLoadedArray;
+        state.systemRegisterVendorsLoaded = true;
+      })
+      .addCase(fetchSystemRegisterVendors.rejected, (state, action) => {
+        state.systemRegisterError = action.error.message ?? 'Unknown error';
+      })
       .addCase(postNewSystemUser.fulfilled, (state) => {
         state.postConfirmed = true;
       })


### PR DESCRIPTION
## Description
So far we have mocked the choices of vendors (firms providing system user software) 
at the Frontend level.

With the new endpoint the DTO is fetched from the BFF, and the data passed
on to the Redux State.

Then the CreationPage has the vendors available, from Redux, for the pull-down menu.

However, the API call is made only once (the API call pattern is not clear yet),
and there are design improvements to be made too,
thus the code in CreationPage must be improved in future iterations
(see comments).


## Related Issue(s)
- #94 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green


