### PR TITLE
Automatic update of OverviewPage after post-confirmation user interaction in CreationPage

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.module.css
+++ b/frontend/src/features/creationpage/CreationPageContent.module.css
@@ -62,6 +62,12 @@
   display: flex;
 }
 
+.confirmationText {
+  margin: 10px;
+  display: flex;
+
+}
+
 
 @media only screen and (min-width: 769px) {
 

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -4,17 +4,19 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, Link } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { postNewSystemUser, CreationRequest } from '@/rtk/features/creationPage/creationPageSlice';
+import { postNewSystemUser, CreationRequest, resetPostConfirmation } from '@/rtk/features/creationPage/creationPageSlice';
+import { fetchOverviewPage } from '@/rtk/features/overviewPage/overviewPageSlice';
 import { TextField, Button, Select } from '@digdir/design-system-react';
 import classes from './CreationPageContent.module.css';
 import { useMediaQuery } from '@/resources/hooks';
+
 
 
 export const CreationPageContent = () => {
 
   // Merk! Det er multiple design og datastruktur-valg som ikke er gjort ennå
   // som påvirker denne siden: dette er annotert nedunder
-  
+
   // Local State variables for input-boxes and Nedtrekksmeny:
   const [integrationName, setIntegrationName] = useState('');
   const [descriptionEntered, setDescriptionEntered] = useState(''); // mulig denne skal populeres fra 
@@ -58,6 +60,14 @@ export const CreationPageContent = () => {
     // Men vi har creationPageSlice status "posted" nå... men den virker bare først gang
     console.log("Automatisk navigering til OverviewPage er inaktivert");
     // navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  }
+
+  const handlePostConfirmation = () => {
+    // skrevet av Github Copilot
+    void dispatch(resetPostConfirmation()); // Github Copilot
+    void dispatch(fetchOverviewPage()); // så får vi se om Redux responderer
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+    
   }
 
 
@@ -223,7 +233,9 @@ export const CreationPageContent = () => {
                 <br></br>
                 <p>Github Copilot skrev denne blokken for meg.</p>
                 <br></br>
-                <button>Gå til oversiktsside</button>
+                <button
+                  onClick={handlePostConfirmation}
+                >Gå til oversiktsside</button>
                 
               </div>
             }

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -56,7 +56,8 @@ export const CreationPageContent = () => {
     // NB! navigasjon til OverviewPage skal vise med ny GET request den nye SystemBruker
     // ettersom vi ikke har noen annen suksess-melding ennå:
     // Men vi har creationPageSlice status "posted" nå... men den virker bare først gang
-    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+    console.log("Automatisk navigering til OverviewPage er inaktivert");
+    // navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
 
@@ -129,7 +130,13 @@ export const CreationPageContent = () => {
   const handleChangeInput = (val: string) => {
     setSelectedSystemType(val);
   };
+
+  const postConfirmed = useAppSelector((state) => state.creationPage.postConfirmed);
+  const postConfirmationId = useAppSelector((state) => state.creationPage.postConfirmationId);
  
+  // console.log("postConfirmed: " + postConfirmed); // Github Copilot
+  // console.log("postConfirmationId: " + postConfirmationId); // Github Copilot
+
   return (
     <div className={classes.creationPageContainer}>
       <div className={classes.inputContainer}> 
@@ -184,6 +191,7 @@ export const CreationPageContent = () => {
             .
           </p>
 
+          { !postConfirmed &&
           <div className={classes.buttonContainer}>
             <div className={classes.cancelButton}>
               <Button
@@ -204,7 +212,21 @@ export const CreationPageContent = () => {
                 Opprett 
               </Button> 
             </div>
+            
+
           </div>
+          }
+          {
+              postConfirmed && 
+              <div className={classes.confirmationText}>
+                <p>Systembruker opprettet med id: {postConfirmationId}</p>
+                <br></br>
+                <p>Github Copilot skrev denne blokken for meg.</p>
+                <br></br>
+                <button>Gå til oversiktsside</button>
+                
+              </div>
+            }
 
         </div>      
       </div>

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -13,11 +13,13 @@ import { useMediaQuery } from '@/resources/hooks';
 export const CreationPageContent = () => {
 
   // Merk! Det er multiple design og datastruktur-valg som ikke er gjort ennå
-  // som påvirker denne siden: dette er annotert under hvert punkt
+  // som påvirker denne siden: dette er annotert nedunder
   
   // Local State variables for input-boxes and Nedtrekksmeny:
   const [integrationName, setIntegrationName] = useState('');
-  const [descriptionEntered, setDescriptionEntered] = useState('');
+  const [descriptionEntered, setDescriptionEntered] = useState(''); // mulig denne skal populeres fra 
+  // fra nedtrekksmeny??
+  
   const [selectedSystemType, setSelectedSystemType] = useState('');
   const [vendorsArrayPopulated, setVendorsArrayPopulated] = useState(false); // not used yet
 
@@ -58,7 +60,10 @@ export const CreationPageContent = () => {
   }
 
 
-  const systemRegisterVendorsArray = useAppSelector((state) => state.creationPage.systemRegisterVendorsArray);
+  // Per 15.11.23: we use a list of vendors for PullDownMenu directly from Redux
+  const vendorsList : { label: string, value: string  }[] = useAppSelector((state) => state.creationPage.systemRegisterVendorsArray);
+
+  // const systemRegisterVendorsArray = useAppSelector((state) => state.creationPage.systemRegisterVendorsArray);
 
   // MOCK VALUES for NedtrekksMeny: List of Firms/Products not available from BFF yet
   // options med label skilt fra value (samme verdi for demo)
@@ -86,6 +91,7 @@ export const CreationPageContent = () => {
   // TOMT OBJEKT er for at Designsystem Nedtrekksmeny ikke skal
   // ha noe tomt øverst
 
+  /* 
   let testoptions: { label: string, value: string  }[] = [
     {
       "label": "",
@@ -96,9 +102,13 @@ export const CreationPageContent = () => {
       "value": "Visma AS (936796702): Visma Økonomi"
     },
   ];
+  */
 
-  const systemRegisterVendorsLoaded = useAppSelector((state) => state.creationPage.systemRegisterVendorsLoaded);
+   
+  
+  // const systemRegisterVendorsLoaded = useAppSelector((state) => state.creationPage.systemRegisterVendorsLoaded);
 
+  /*
   // NB! foreløpig løsning: bør gjøres til funksjonell komponent
   if (systemRegisterVendorsLoaded ) {
     // console.log("Burde bygge vendorsArray bare en gang, men endelig design ikke klart.");
@@ -112,6 +122,7 @@ export const CreationPageContent = () => {
       );
     };
   };
+  */
 
 
   // Håndterer skifte av valgmuligheter (options) i Nedtrekksmeny
@@ -155,9 +166,9 @@ export const CreationPageContent = () => {
           <div className={classes.selectWrapper}>
             <Select
               label="Velg systemleverandør og system"
-              options={testoptions}
-              onChange={handleChangeInput}
-              value={selectedSystemType}
+              options={ vendorsList }
+              onChange={ handleChangeInput }
+              value={ selectedSystemType }
             />
           </div>
         </div>

--- a/frontend/src/features/overviewpage/OverviewPage.tsx
+++ b/frontend/src/features/overviewpage/OverviewPage.tsx
@@ -24,7 +24,7 @@ export const OverviewPage = () => {
   // må finne mer elegang måte å gjøre dette på: og dynamisk: vil bare laste 1 gang tror jeg
   useEffect(() => {
     if (!overviewLoaded) {
-      console.log("Prøver laste inn OverviewPage og CreationPage data til Redux");
+      console.log("Førstegangs innlasting av OverviewPage og CreationPage data til Redux");
       void dispatch(fetchOverviewPage());
       void dispatch(fetchSystemRegisterVendors()); // for CreationPage: see issue #94
     }

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -14,6 +14,10 @@ import { useTranslation } from 'react-i18next';
 
 export const OverviewPageContent = () => {
 
+  console.log(" ");
+  console.log("Teller antall ganger OverviewPageContent rendres"); //Copilot!
+  console.log("***********************************************");
+
   const { t } = useTranslation('common');
   const navigate = useNavigate();
 
@@ -80,34 +84,6 @@ export const OverviewPageContent = () => {
       </h2>
 
       { reduxCollectionBarArray() }
-
-
-      <CollectionBar
-        title='System lakselus rapportering'
-        subtitle='AQUA POWER'
-        color={'neutral'}
-        collection={[]}
-        compact={isSm}
-        proceedToPath={
-          '/fixpath/'
-        }
-      />
-
-      <div>
-        <br></br>
-      </div>
-
-      <CollectionBar
-        title='Økonomisystem'
-        subtitle='VISMA ACCOUNTING'
-        additionalText='Delegert til Visma AS'
-        color={ 'neutral' }
-        collection={[]}
-        compact={isSm}
-        proceedToPath={
-          '/fixpath/'
-        }
-      />
 
     </div>
   );

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -12,8 +12,13 @@ export interface SystemRegisterObjectDTO {
   description: string;
 }
 
+export interface SystemRegisterObjectPresented {
+  label: string;
+  value: string;
+}
+
 export interface SliceState {
-  systemRegisterVendorsArray: SystemRegisterObjectDTO[];
+  systemRegisterVendorsArray: SystemRegisterObjectPresented[];
   systemRegisterVendorsLoaded: boolean;
   systemRegisterError: string;
   postConfirmed: boolean;
@@ -70,19 +75,27 @@ const creationPageSlice = createSlice({
     builder
       .addCase(fetchSystemRegisterVendors.fulfilled, (state, action) => {
         const dataArray = action.payload;
-        const downLoadedArray: SystemRegisterObjectDTO[] = [];
+        const downLoadedArray: SystemRegisterObjectPresented[] = [];
 
         for (let i = 0; i < dataArray.length; i++) {
           const systemTypeId = dataArray[i].systemTypeId;
           const systemVendor = dataArray[i].systemVendor;
-          const description = dataArray[i].description;
+          // const description = dataArray[i].description; // not in use per 15.11.23
 
-          const loopObject = {
+          /* const loopObject = {
               systemTypeId,
               systemVendor,
               description,
             };
-            downLoadedArray.push(loopObject);
+            */
+          // transform to DesignSystem PullDownMenu shape
+          // we do not use "description" (so far: designers might )
+          const loopObject2 = {
+            'label': `${systemTypeId} : ${systemVendor}`,
+            'value': `${systemTypeId} : ${systemVendor}`
+          }
+
+          downLoadedArray.push(loopObject2);
         }
 
         state.systemRegisterVendorsArray = downLoadedArray;

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -72,7 +72,13 @@ export const postNewSystemUser = createAsyncThunk('creationPageSlice/postNewSyst
 const creationPageSlice = createSlice({
   name: 'creation',
   initialState,
-  reducers: {},
+  reducers: {
+    resetPostConfirmation: (state) => {
+      state.postConfirmed = false;
+      state.postConfirmationId = '';
+      // skrevet av Github Copilot
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchSystemRegisterVendors.fulfilled, (state, action) => {
@@ -116,4 +122,5 @@ const creationPageSlice = createSlice({
   },
 });
 
+export const { resetPostConfirmation } = creationPageSlice.actions; // Github Copilot
 export default creationPageSlice.reducer;

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -23,6 +23,7 @@ export interface SliceState {
   systemRegisterError: string;
   postConfirmed: boolean;
   creationError: string;
+  postConfirmationId: string;
 }
 
 const initialState: SliceState = {
@@ -31,6 +32,7 @@ const initialState: SliceState = {
     systemRegisterError: '',
     postConfirmed: false,
     creationError: '',
+    postConfirmationId: '',
 };
 
 // CreationRequest form is based on Swagger POST description per 25.10.23
@@ -104,8 +106,9 @@ const creationPageSlice = createSlice({
       .addCase(fetchSystemRegisterVendors.rejected, (state, action) => {
         state.systemRegisterError = action.error.message ?? 'Unknown error';
       })
-      .addCase(postNewSystemUser.fulfilled, (state) => {
+      .addCase(postNewSystemUser.fulfilled, (state, action) => {
         state.postConfirmed = true;
+        state.postConfirmationId = action.payload;
       })
       .addCase(postNewSystemUser.rejected, (state, action) => {
         state.creationError = action.error.message ?? 'Unknown error';

--- a/frontend/src/rtk/features/creationPage/creationPageSlice.ts
+++ b/frontend/src/rtk/features/creationPage/creationPageSlice.ts
@@ -108,7 +108,7 @@ const creationPageSlice = createSlice({
       })
       .addCase(postNewSystemUser.fulfilled, (state, action) => {
         state.postConfirmed = true;
-        state.postConfirmationId = action.payload;
+        state.postConfirmationId = action.payload.id;
       })
       .addCase(postNewSystemUser.rejected, (state, action) => {
         state.creationError = action.error.message ?? 'Unknown error';


### PR DESCRIPTION
## Description
The OverviewPage is now automatically updated (from Redux State)
after a new user interaction step has been added in CreationPage.

After clicking confirm/Opprett, the user gets a confirmation
(and the new POST id return update, see Issue8) upon a successful
creation of a new SystemUser (in both BFF, Real Backend etc...)

When he clicks the OK button, the state of the CreationPage is reset,
a GET request to BFF for an update OverviewPage list is sent,
and the user transferred to the OverviewPage.

The BrowserBackButton scenario will be dealt with in a future iteration.

Design for the new user interaction is not in yet.


## Related Issue(s)
- #107 #8 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
