### PR TITLE
CreationPage iteration21 make confirmation button green and Azure app update timed

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.module.css
+++ b/frontend/src/features/creationpage/CreationPageContent.module.css
@@ -49,7 +49,13 @@
   display: flex;
   justify-content: flex-end;
   margin-top: 10rem;
-  
+}
+
+.confirmationContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10rem;
+  align-items: center;
 }
 
 .cancelButton {

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -122,15 +122,7 @@ export const CreationPageContent = () => {
         </div>
 
         <div className={classes.rightContainer}>
-          <h3 className={classes.header}>Eget system?</h3>
-          <p className={classes.contentText}>
-            Hvis du har et eget system du ønsker å benytte, 
-            opprett integrasjon i maskinporten 
-            <Link
-            to={'/' + AuthenticationPath.Auth + '/' + AuthenticationPath.MaskinportenAdm}
-            > her</Link> 
-            .
-          </p>
+          
 
           { !postConfirmed &&
           <div className={classes.buttonContainer}>
@@ -158,17 +150,22 @@ export const CreationPageContent = () => {
 
           {
               postConfirmed && 
-              <div className={classes.confirmationText}>
-                <p>Systembruker opprettet med id: {postConfirmationId}</p>
-                <br></br>
-                <p>Github Copilot skrev denne blokken for meg.</p>
-                <br></br>
-                <button
-                  onClick={handlePostConfirmation}
-                >Gå til oversiktsside</button>
-                
+              <div className={classes.buttonContainer}>
+                <div className={classes.confirmationText}>
+                  <p>Systembruker opprettet</p>
+                </div>
+
+                <div className={classes.confirmButton}>
+                  <Button
+                    color='success'
+                    size='small'
+                    onClick={handlePostConfirmation}
+                  >
+                    OK 
+                  </Button> 
+                </div>
               </div>
-            }
+          }
 
         </div>      
       </div>

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -133,7 +133,7 @@ export const CreationPageContent = () => {
                 size='small'
                 onClick={handleReject}
               >
-                Avbryt 
+                Avbryt
               </Button> 
             </div>
             <div className={classes.confirmButton}>
@@ -150,7 +150,8 @@ export const CreationPageContent = () => {
 
           {
               postConfirmed && 
-              <div className={classes.buttonContainer}>
+              <div className={classes.confirmationContainer}>
+
                 <div className={classes.confirmationText}>
                   <p>Systembruker opprettet</p>
                 </div>


### PR DESCRIPTION
## Description
After discussion in our Live Online Prototype Demo today,
the feedback from our users indicated that another
iteration of the confirmation message on CreationPage,
was in order.

The ugly confirmation message,
has now been replaced with a prettier 
green button.

Future iterations might improve this confirmation step even further.

Also, this is a test of the live update of our online Azure app. The 
update will be timed after merge, so that stakeholders might be 
later informed on how fast our pipeline is running, and when they
can expect to see the change.


## Related Issue(s)
- #90 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
