### PR TITLE
First iteration of new ConfirmationPage as per new Design of 24.11.23

### DIFF
--- a/frontend/src/features/confirmationpage/ConfirmationPage.tsx
+++ b/frontend/src/features/confirmationpage/ConfirmationPage.tsx
@@ -16,7 +16,7 @@ export const ConfirmationPage = () => {
         color='dark'
         size={isSm ? 'small' : 'medium'}
       >
-        <PageHeader icon={<ApiIcon />}>{t('authent_creationpage.banner_title')}</PageHeader>
+        <PageHeader icon={<ApiIcon />}>{t('authent_confirmationpage.banner_title')}</PageHeader>
         <PageContent>
           <ConfirmationPageContent />
         </PageContent>

--- a/frontend/src/features/confirmationpage/ConfirmationPage.tsx
+++ b/frontend/src/features/confirmationpage/ConfirmationPage.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+import { Page, PageHeader, PageContent, PageContainer } from '@/components';
+import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
+import { useMediaQuery } from '@/resources/hooks';
+import { ConfirmationPageContent } from './ConfirmationPageContent';
+
+
+export const ConfirmationPage = () => {
+  const { t } = useTranslation('common');
+  const isSm = useMediaQuery('(max-width: 768px)');
+  
+  return (
+    <PageContainer>
+      <Page
+        color='dark'
+        size={isSm ? 'small' : 'medium'}
+      >
+        <PageHeader icon={<ApiIcon />}>{t('authent_creationpage.banner_title')}</PageHeader>
+        <PageContent>
+          <ConfirmationPageContent />
+        </PageContent>
+      </Page>
+    </PageContainer>
+  );
+};

--- a/frontend/src/features/confirmationpage/ConfirmationPageContent.module.css
+++ b/frontend/src/features/confirmationpage/ConfirmationPageContent.module.css
@@ -1,0 +1,117 @@
+.confirmationPageContainer {
+  margin-left: 40px;
+  margin-right: 40px;
+  margin-top: 10px;
+}
+
+.inputContainer {
+  display: flex;
+  justify-content: normal;
+  margin-top: 10px;
+}
+
+.nameWrapper {
+  margin: 10px;
+}
+
+.descriptionWrapper {
+  margin: 10px;
+}
+
+.header {
+  margin-top: 20px;
+  font-weight: 500;
+}
+
+
+.flexContainer {
+  display: flex;
+}
+
+.leftContainer {
+  flex: 3;
+  margin-right: 1rem;
+}
+
+.rightContainer {
+  flex: 3;
+}
+
+
+
+.selectWrapper {
+  margin: 10px;
+  margin-bottom: 2rem;
+  margin-top: 1rem;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10rem;
+}
+
+.confirmationContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10rem;
+  align-items: center;
+}
+
+.cancelButton {
+  margin: 10px;
+  display: flex;
+}
+
+.confirmButton {
+  margin: 10px;
+  display: flex;
+}
+
+.confirmationText {
+  margin: 10px;
+  display: flex;
+
+}
+
+
+@media only screen and (min-width: 769px) {
+
+  .contentText {
+    font-size: 16px;
+  }
+  
+}
+
+@media only screen and (max-width: 768px) {
+
+  .contentText {
+    font-size: 14px;
+  }
+
+  .header {
+    font-size: 16px;
+  }
+
+}
+
+
+@media only screen and (max-width: 576px) {
+
+  .flexContainer {
+    flex-direction: column;
+  }
+
+  .inputContainer {
+    flex-direction: column;
+  }
+
+  .creationPageContainer {
+    margin-top: 1rem;
+  }
+
+  .contentText {
+    font-size: 14px;
+  }
+
+}

--- a/frontend/src/features/confirmationpage/ConfirmationPageContent.module.css
+++ b/frontend/src/features/confirmationpage/ConfirmationPageContent.module.css
@@ -4,76 +4,34 @@
   margin-top: 10px;
 }
 
-.inputContainer {
-  display: flex;
-  justify-content: normal;
-  margin-top: 10px;
-}
-
-.nameWrapper {
-  margin: 10px;
-}
-
-.descriptionWrapper {
-  margin: 10px;
-}
-
 .header {
   margin-top: 20px;
   font-weight: 500;
+  font-size: 22px;
 }
-
 
 .flexContainer {
   display: flex;
-}
-
-.leftContainer {
-  flex: 3;
-  margin-right: 1rem;
 }
 
 .rightContainer {
   flex: 3;
 }
 
-
-
-.selectWrapper {
-  margin: 10px;
-  margin-bottom: 2rem;
-  margin-top: 1rem;
-}
-
 .buttonContainer {
   display: flex;
-  justify-content: flex-end;
-  margin-top: 10rem;
+  margin-top: 6rem;
 }
 
-.confirmationContainer {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 10rem;
-  align-items: center;
-}
-
-.cancelButton {
+.addRightsButton {
   margin: 10px;
   display: flex;
 }
 
-.confirmButton {
+.addNoRightsButton {
   margin: 10px;
   display: flex;
 }
-
-.confirmationText {
-  margin: 10px;
-  display: flex;
-
-}
-
 
 @media only screen and (min-width: 769px) {
 
@@ -90,7 +48,7 @@
   }
 
   .header {
-    font-size: 16px;
+    font-size: 18px;
   }
 
 }
@@ -99,10 +57,6 @@
 @media only screen and (max-width: 576px) {
 
   .flexContainer {
-    flex-direction: column;
-  }
-
-  .inputContainer {
     flex-direction: column;
   }
 

--- a/frontend/src/features/confirmationpage/ConfirmationPageContent.tsx
+++ b/frontend/src/features/confirmationpage/ConfirmationPageContent.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, Link } from 'react-router-dom';
+import { AuthenticationPath } from '@/routes/paths';
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { postNewSystemUser, CreationRequest, resetPostConfirmation } from '@/rtk/features/creationPage/creationPageSlice';
+import { fetchOverviewPage } from '@/rtk/features/overviewPage/overviewPageSlice';
+import { TextField, Button, Select } from '@digdir/design-system-react';
+import classes from './ConfirmationPageContent.module.css';
+import { useMediaQuery } from '@/resources/hooks';
+
+
+
+export const ConfirmationPageContent = () => {
+
+  // Merk! Det er multiple design og datastruktur-valg som ikke er gjort ennå
+  // som påvirker denne siden: dette er annotert nedunder
+
+  // Local State variables for input-boxes and Nedtrekksmeny:
+  const [integrationName, setIntegrationName] = useState('');
+
+  // mulig denne skal populeres fra nedtrekksmeny?? Design mangler
+  const [descriptionEntered, setDescriptionEntered] = useState(''); 
+  
+  
+  const [selectedSystemType, setSelectedSystemType] = useState('');
+  
+  // const [vendorsArrayPopulated, setVendorsArrayPopulated] = useState(false); // not used yet
+
+  const { t } = useTranslation('common'); 
+
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch(); 
+  
+  // brukes i h2, ikke vist i Small/mobile view
+  const isSm = useMediaQuery('(max-width: 768px)'); // fix-me: trengs denne?
+  let overviewText: string;
+  overviewText = 'Knytt systembruker til systemleverandør'; 
+
+  const handleReject = () => {
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  }
+
+  const handleConfirm = () => {
+    // POST 3 useState variables, while the last two not yet implemented
+    const PostObjekt: CreationRequest = {
+      integrationTitle: integrationName,
+      description: descriptionEntered,
+      selectedSystemType: selectedSystemType,
+      clientId: "notImplemented",
+      ownedByPartyId: "notImplemented"
+    };
+
+    void dispatch(postNewSystemUser(PostObjekt));  
+    
+    // Clean up local State variables before returning to main page
+    setIntegrationName('');
+    setDescriptionEntered('');
+    setSelectedSystemType('');
+  }
+
+  const handlePostConfirmation = () => {
+    // skrevet av Github Copilot
+    void dispatch(resetPostConfirmation());
+    void dispatch(fetchOverviewPage()); 
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
+  }
+
+  // Per 15.11.23: we use a list of vendors for PullDownMenu directly from Redux
+  const vendorsList : { label: string, value: string  }[] = useAppSelector((state) => state.creationPage.systemRegisterVendorsArray);
+
+  // Håndterer skifte av valgmuligheter (options) i Nedtrekksmeny
+  // Fix-me: Bør sjekke om DesignSystem dokumentasjon er oppdatert
+  const handleChangeInput = (val: string) => {
+    setSelectedSystemType(val);
+  };
+
+  const postConfirmed = useAppSelector((state) => state.creationPage.postConfirmed);
+  const postConfirmationId = useAppSelector((state) => state.creationPage.postConfirmationId);
+ 
+  return (
+    <div className={classes.confirmationPageContainer}>
+      <div className={classes.inputContainer}> 
+        <div className={classes.nameWrapper}>
+            <TextField 
+              label = {t('authent_creationpage.input_field_label')} 
+              value = { integrationName }
+              onChange={e => setIntegrationName(e.target.value)}
+            />
+        </div>
+      </div>
+
+      <h2 className={classes.header}>{t('authent_creationpage.sub_title')}</h2>
+
+      <p className={classes.contentText}>
+        {t('authent_creationpage.content_text1')}
+      </p>
+
+      <p className={classes.contentText}>
+        {t('authent_creationpage.content_text2')}
+      </p>
+
+      <div className={classes.flexContainer}>
+        <div className={classes.leftContainer}>
+          <div className={classes.selectWrapper}>
+            <Select
+              label={t('authent_creationpage.pull_down_menu_label')}
+              options={ vendorsList }
+              onChange={ handleChangeInput }
+              value={ selectedSystemType }
+            />
+          </div>
+        </div>
+
+        <div className={classes.rightContainer}>
+          
+
+          { !postConfirmed &&
+          <div className={classes.buttonContainer}>
+            <div className={classes.confirmButton}>
+              <Button
+                color='primary'
+                size='small'
+                onClick={handleConfirm}
+              >
+                {t('authent_creationpage.confirm_button')} 
+              </Button> 
+            </div>
+            <div className={classes.cancelButton}>
+              <Button
+                color='primary'
+                variant='quiet'
+                size='small'
+                onClick={handleReject}
+              >
+                {t('authent_creationpage.cancel_button')} 
+              </Button> 
+            </div>
+          </div>
+          }
+
+          {
+              postConfirmed && 
+              <div className={classes.confirmationContainer}>
+
+                <div className={classes.confirmationText}>
+                  <p>Systembruker opprettet</p>
+                </div>
+
+                <div className={classes.confirmButton}>
+                  <Button
+                    color='success'
+                    size='small'
+                    onClick={handlePostConfirmation}
+                  >
+                    OK 
+                  </Button> 
+                </div>
+              </div>
+          }
+
+        </div>      
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/confirmationpage/ConfirmationPageContent.tsx
+++ b/frontend/src/features/confirmationpage/ConfirmationPageContent.tsx
@@ -81,83 +81,40 @@ export const ConfirmationPageContent = () => {
  
   return (
     <div className={classes.confirmationPageContainer}>
-      <div className={classes.inputContainer}> 
-        <div className={classes.nameWrapper}>
-            <TextField 
-              label = {t('authent_creationpage.input_field_label')} 
-              value = { integrationName }
-              onChange={e => setIntegrationName(e.target.value)}
-            />
-        </div>
-      </div>
 
-      <h2 className={classes.header}>{t('authent_creationpage.sub_title')}</h2>
+      <h2 className={classes.header}>{t('authent_confirmationpage.sub_title')}</h2>
 
       <p className={classes.contentText}>
-        {t('authent_creationpage.content_text1')}
+        {t('authent_confirmationpage.content_text')}
       </p>
 
-      <p className={classes.contentText}>
-        {t('authent_creationpage.content_text2')}
-      </p>
 
       <div className={classes.flexContainer}>
-        <div className={classes.leftContainer}>
-          <div className={classes.selectWrapper}>
-            <Select
-              label={t('authent_creationpage.pull_down_menu_label')}
-              options={ vendorsList }
-              onChange={ handleChangeInput }
-              value={ selectedSystemType }
-            />
-          </div>
-        </div>
-
         <div className={classes.rightContainer}>
           
-
           { !postConfirmed &&
           <div className={classes.buttonContainer}>
-            <div className={classes.confirmButton}>
+
+            <div className={classes.addRightsButton}>
               <Button
                 color='primary'
-                size='small'
-                onClick={handleConfirm}
-              >
-                {t('authent_creationpage.confirm_button')} 
-              </Button> 
-            </div>
-            <div className={classes.cancelButton}>
-              <Button
-                color='primary'
-                variant='quiet'
                 size='small'
                 onClick={handleReject}
               >
-                {t('authent_creationpage.cancel_button')} 
+                {t('authent_confirmationpage.add_rights_button')} 
+              </Button> 
+            </div>
+            <div className={classes.addNoRightsButton}>
+              <Button
+                color='primary'
+                variant='outline'
+                size='small'
+                onClick={handleReject}
+              >
+                {t('authent_confirmationpage.add_no_rights_button')} 
               </Button> 
             </div>
           </div>
-          }
-
-          {
-              postConfirmed && 
-              <div className={classes.confirmationContainer}>
-
-                <div className={classes.confirmationText}>
-                  <p>Systembruker opprettet</p>
-                </div>
-
-                <div className={classes.confirmButton}>
-                  <Button
-                    color='success'
-                    size='small'
-                    onClick={handlePostConfirmation}
-                  >
-                    OK 
-                  </Button> 
-                </div>
-              </div>
           }
 
         </div>      

--- a/frontend/src/features/confirmationpage/index.ts
+++ b/frontend/src/features/confirmationpage/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmationPage } from './ConfirmationPage';

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -62,6 +62,16 @@
     "confirm_button": "Opprett systembrukar",
     "cancel_button": "Avbryt"
   },
+  "authent_confirmationpage": {
+    "banner_title": "Opprett ny systembrukar",
+    "input_field_label": "Namn på systembrukar",
+    "sub_title": "Knytt systembrukar til systemleverandør",
+    "content_text1": "I dei fleste tilfelle vil systembrukaren nyttast i samanheng med sluttbrukarsystemer levert av ulike leverandørar. Det fins ei rekke leverandørar og systemer i marknaden som tilbyr systemer for ulike typar bruk. Du må sjølv gjere ei sjølvstendig vurdering på valg av leverandør og system.",
+    "content_text2": "Nedenfor listast alle leverandørar og systemer som har meldt at dei leverer slike tenester. Altinn har ikkje gjort noko vurdering av desse.",
+    "pull_down_menu_label": "Velg systemleverandør og system",
+    "confirm_button": "Opprett systembrukar",
+    "cancel_button": "Avbryt"
+  },
   "authentication_dummy": {
     "auth_title_systembrukere": "Systembrukere",
     "auth_overview_text_administrere": "Her kan du administrere dine systembrukere",

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -63,14 +63,11 @@
     "cancel_button": "Avbryt"
   },
   "authent_confirmationpage": {
-    "banner_title": "Opprett ny systembrukar",
-    "input_field_label": "Namn på systembrukar",
-    "sub_title": "Knytt systembrukar til systemleverandør",
-    "content_text1": "I dei fleste tilfelle vil systembrukaren nyttast i samanheng med sluttbrukarsystemer levert av ulike leverandørar. Det fins ei rekke leverandørar og systemer i marknaden som tilbyr systemer for ulike typar bruk. Du må sjølv gjere ei sjølvstendig vurdering på valg av leverandør og system.",
-    "content_text2": "Nedenfor listast alle leverandørar og systemer som har meldt at dei leverer slike tenester. Altinn har ikkje gjort noko vurdering av desse.",
-    "pull_down_menu_label": "Velg systemleverandør og system",
-    "confirm_button": "Opprett systembrukar",
-    "cancel_button": "Avbryt"
+    "banner_title": "Ny systembrukar er oppretta",
+    "sub_title": "Du har no oppretta systembrukaren Turboskatt, som er knytta til Visma Accounting",
+    "content_text": "Du kan velga å gå vidare og gje systembrukaren rettar, eller avslutte og komme attende seinare.",  
+    "add_rights_button": "Legg til rettar",
+    "add_no_rights_button": "Legg til rettar seinare"
   },
   "authentication_dummy": {
     "auth_title_systembrukere": "Systembrukere",

--- a/frontend/src/localizations/no_nn.json
+++ b/frontend/src/localizations/no_nn.json
@@ -64,6 +64,17 @@
     "confirm_button": "Opprett systembruker",
     "cancel_button": "Avbryt"
   },
+
+  "authent_confirmationpage": {
+    "banner_title": "Opprett ny systembruker",
+    "input_field_label": "Navn på systembruker",
+    "sub_title": "Knytt systembruker til systemleverandør",
+    "content_text1": "I de fleste tilfeller vil systembrukeren benyttes i sammenheng med  sluttbrukersystemer levert av forskjellige leverandører. Det er en rekke leverandører og systemer i markedet som tilbyr systemer for forskjellig bruk. Du må selv gjøre en selvstendig vurdering på valg av leverandør og system.",
+    "content_text2": "Nedenfor listes alle leverandører og systemer som har meldt at de leverer slike tjenester. Altinn har ikke gjort noen vurdering av disse.",
+    "pull_down_menu_label": "Velg systemleverandør og system",
+    "confirm_button": "Opprett systembruker",
+    "cancel_button": "Avbryt"
+  },
   
   "authentication_dummy": {
     "auth_title_systembrukere": "Systembrukere",

--- a/frontend/src/localizations/no_nn.json
+++ b/frontend/src/localizations/no_nn.json
@@ -66,14 +66,11 @@
   },
 
   "authent_confirmationpage": {
-    "banner_title": "Opprett ny systembruker",
-    "input_field_label": "Navn på systembruker",
-    "sub_title": "Knytt systembruker til systemleverandør",
-    "content_text1": "I de fleste tilfeller vil systembrukeren benyttes i sammenheng med  sluttbrukersystemer levert av forskjellige leverandører. Det er en rekke leverandører og systemer i markedet som tilbyr systemer for forskjellig bruk. Du må selv gjøre en selvstendig vurdering på valg av leverandør og system.",
-    "content_text2": "Nedenfor listes alle leverandører og systemer som har meldt at de leverer slike tjenester. Altinn har ikke gjort noen vurdering av disse.",
-    "pull_down_menu_label": "Velg systemleverandør og system",
-    "confirm_button": "Opprett systembruker",
-    "cancel_button": "Avbryt"
+    "banner_title": "Ny systembruker er opprettet",
+    "sub_title": "Du har nå opprettet systembrukeren Turboskatt, som er knyttet til Visma Accounting",
+    "content_text": "Du kan velge å gå videre og gi systembrukeren rettigheter, eller avslutte og komme tilbake senere.",
+    "add_rights_button": "Legg til rettigheter",
+    "add_no_rights_button": "Legg til rettigheter senere" 
   },
   
   "authentication_dummy": {

--- a/frontend/src/routes/Router/Router.tsx
+++ b/frontend/src/routes/Router/Router.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { OverviewPage } from '@/features/overviewpage/OverviewPage';
 import { CreationPage } from '@/features/creationpage/CreationPage';
+import { ConfirmationPage } from '@/features/confirmationpage/ConfirmationPage';
 import { DirectConsentPage } from '@/features/directconsentpage/DirectConsentPage';
 import { MaskinportenAdmPage } from '@/features/maskinportenAdm/MaskinportenAdmPage';
 
@@ -30,6 +31,12 @@ export const Router = createBrowserRouter(
         <Route
           path={AuthenticationPath.Creation}
           element={<CreationPage />}
+          errorElement={<NotFoundSite />}
+        />
+
+        <Route
+          path={AuthenticationPath.Confirmation}
+          element={<ConfirmationPage />}
           errorElement={<NotFoundSite />}
         />
 

--- a/frontend/src/routes/paths/AuthenticationPath.tsx
+++ b/frontend/src/routes/paths/AuthenticationPath.tsx
@@ -1,7 +1,7 @@
 export enum AuthenticationPath {
   Auth = 'auth',
   Creation = 'creation',
-  CustomCreation = 'customcreation',
+  Confirmation = 'confirmation',
   Overview = 'overview',
   DirectConsent = 'directconsent',
   MaskinportenAdm = 'maskinportenadm'


### PR DESCRIPTION
## Description

The superficial features of the new ConfirmationPage is now set up,
and is reachable at the /confirmation path.

The buttons are not yet functional (they will both return the user to OverviewPage).


## Related Issue(s)
- #128 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] User documentation is updated in Repo Wiki
