### PR TITLE
Link up new ConfirmationPage with user flow no.1 via CreationPage

### DIFF
--- a/frontend/src/features/confirmationpage/ConfirmationPageContent.tsx
+++ b/frontend/src/features/confirmationpage/ConfirmationPageContent.tsx
@@ -93,6 +93,9 @@ export const ConfirmationPageContent = () => {
         <div className={classes.rightContainer}>
           
           { !postConfirmed &&
+            <p>Ikke helt bekreftet ennå: må håndteres</p>
+          }
+
           <div className={classes.buttonContainer}>
 
             <div className={classes.addRightsButton}>
@@ -115,7 +118,7 @@ export const ConfirmationPageContent = () => {
               </Button> 
             </div>
           </div>
-          }
+          
 
         </div>      
       </div>

--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -54,12 +54,20 @@ export const CreationPageContent = () => {
 
     void dispatch(postNewSystemUser(PostObjekt));  
     
-    // Clean up local State variables before returning to main page
+    // Clean up local State variables before returning to main page, was old solution
+    // update 07.12.23: New Design of 24.11.23 specifies navigation
+    // to ConfirmationPage: OK, but if CreationRequest fails we need to
+    // notify the user, but perhaps we could do it on the ConfirmationPage?
     setIntegrationName('');
     setDescriptionEntered('');
     setSelectedSystemType('');
+
+    // Crude first pass at problem: no Error handling here or at ConfirmationPage OK
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Confirmation);
   }
 
+  // The old solution: waited for confirmation before
+  // navigating to OverviewPage: 
   const handlePostConfirmation = () => {
     // skrevet av Github Copilot
     void dispatch(resetPostConfirmation());


### PR DESCRIPTION
## Description
In the old solution we had the creation of a new SystemUser 
confirmed from backend before returning to the main page,
the OverviewPage.

The New Design of 24.11.23 specifies navigation to 
the new ConfirmationPage, which is implemented here.

Note that Error-handling is not yet implemented, 
although a (hidden) warning at the ConfirmationPage
accesses the Redux variables postConfirmed (boolean).

Thus further iterations are needed also here.

## Related Issue(s)
- #127 and #128 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] User documentation is updated in Repo Wiki.
