### PR TITLE
Second iteration of DirectConsentPage in line with new design of Flyt2 of 11.12.23

### DIFF
--- a/frontend/src/features/directconsentpage/DirectConsentPage.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPage.tsx
@@ -19,7 +19,7 @@ export const DirectConsentPage = () => {
         color='dark'
         size={isSm ? 'small' : 'medium'}
       >
-        <PageHeader icon={<ApiIcon />}>{'Direkte Samtykke'}</PageHeader>
+        <PageHeader icon={<ApiIcon />}>{t('authent_directconsentpage.banner_title')}</PageHeader>
         <PageContent>
           <DirectConsentPageContent />
         </PageContent>

--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.module.css
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.module.css
@@ -7,6 +7,7 @@
 .header {
   margin-top: -2rem;
   font-weight: 500;
+  font-size: 22px;
 }
 
 .flexContainer {

--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { Button, Spinner } from '@digdir/design-system-react';
+import { Button, Checkbox } from '@digdir/design-system-react';
 import { useEffect, useState } from 'react';
 import { useMediaQuery } from '@/resources/hooks';
 import classes from './DirectConsentPageContent.module.css';
@@ -19,7 +19,7 @@ export const DirectConsentPageContent = () => {
   const isSm = useMediaQuery('(max-width: 768px)');
 
   let overviewText: string;
-  overviewText = t('authentication_dummy.auth_overview_text_directconsent'); // h2 below, not in Small/mobile view
+  overviewText = t('authent_directconsentpage.sub_title'); // h2 below, not in Small/mobile view
 
   // skal nå bare gå tilbake til OverviewPage
   // selv om vi må vurdere en sletting av ting?
@@ -35,8 +35,16 @@ export const DirectConsentPageContent = () => {
     console.log("Her skulle det skjedd noe")
   }
 
+  const handleCheck1 = () => {
+    console.log("Her skulle det skjedd noe")
+  }
 
-  // Må sette inn lag med Page, PageContainer etc... så det ligner
+  const handleCheck2 = () => {
+    console.log("Her skulle det skjedd noe")
+  }
+
+
+  // Fix-me: Må sette inn lag med Page, PageContainer etc... så det ligner
   // på andre sider.
 
   return (
@@ -48,57 +56,63 @@ export const DirectConsentPageContent = () => {
         <div className={classes.leftContainer}>
 
           <p className={classes.contentText}>
-            Fiken AS ber om tilgangsgrupper blir gitt til systemet. <br></br>
-            Tilgangsgruppene vil gi systemintegrasjonen rett til <br></br>
-            å aksessere digitale tjenester på vegne av Pølsebu AS<br></br>
-            <br></br> 
-            <a href="https://altinn.github.io/docs/"> Les mer her</a> og  
-            <a href="https://docs.altinn.studio/nb/"> her</a>. 
-          </p>
-            
-
-            <br></br>
-          <p className={classes.contentText}>
-            Tilgangsgruppene er: <br></br>
-              <br></br>
-              - MVA (se tjenester)<br></br>
-              - Sykemelding (se tjenester)
-              <br></br>
+          {t('authent_directconsentpage.consent_text')}
           </p>
 
-            <br></br>
+          <br></br>
 
           <p className={classes.contentText}>
-            Innholdet i tilgangsgruppene kan endre seg hvis nye
-            tjenester for områdetet blir tilgjengelig.
+          {t('authent_directconsentpage.consent_buttons_top_text')}
           </p>
-            
-          <p className={classes.contentText}>
-            Tilgangsgruppene kan fjernes når som helst senere fra Altinn profil.
-          </p>
-      
+          
+          <div className={classes.checkboxContainer}>
+            <div className={classes.confirmButton}>
+              <Checkbox
+                color='primary'
+                size='small'
+                onClick={handleCheck1}
+              >
+                {t('authent_directconsentpage.add_consent_checkbox1')} 
+              </Checkbox> 
+            </div>
+
+            <div className={classes.confirmButton}>
+              <Checkbox
+                color='primary'
+                size='small'
+                onClick={handleCheck2}
+              >
+                {t('authent_directconsentpage.add_consent_checkbox2')} 
+              </Checkbox> 
+            </div>
+
+          </div>
+          <br></br>
+          <br></br>
 
           <div className={classes.buttonContainer}>
-
-            <div className={classes.cancelButton}>
-              <Button
-                color='primary'
-                variant='outline'
-                size='small'
-                onClick={handleReject}
-              >
-                Avbryt 
-              </Button> 
-            </div>
 
             <div className={classes.confirmButton}>
               <Button
                 color='primary'
                 size='small'
-                onClick={handleConfirm}
+                onClick={handleReject}
               >
-                Opprett 
+                {t('authent_directconsentpage.add_consent_button1')} 
               </Button> 
+              
+            </div>
+
+            <div className={classes.cancelButton}>
+              <Button
+                color='primary'
+                variant='quiet'
+                size='small'
+                onClick={handleReject}
+              >
+                {t('authent_directconsentpage.add_consent_button2')} 
+              </Button> 
+               
             </div>
 
           </div>

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -69,6 +69,17 @@
     "add_rights_button": "Legg til rettar",
     "add_no_rights_button": "Legg til rettar seinare"
   },
+  "authent_directconsentpage": {
+    "banner_title": "Gje tilgang til system",
+    "sub_title": "Visma AS ynskjer å oppretta ein systemtilgang for Olsen Regnskap AS",
+    "consent_text": "Systembrukaren vil nyttast for handsaming av data for Olsen Regnskap AS, eller kunder av Olsen Regnskap AS.",
+    "consent_buttons_top_text": "Eg gjev samtykke til at:",
+    "add_consent_checkbox1": "Visma AS kan handsama data for Olsen Regnskap AS",
+    "add_consent_checkbox2": "Visma AS kan handsama data for kundar av Olsen Regnskap AS", 
+    "add_consent_button1": "Ja, eg gjev samtykke",
+    "add_consent_button2": "Avbryt" 
+  },
+
   "authentication_dummy": {
     "auth_title_systembrukere": "Systembrukere",
     "auth_overview_text_administrere": "Her kan du administrere dine systembrukere",

--- a/frontend/src/localizations/no_nn.json
+++ b/frontend/src/localizations/no_nn.json
@@ -72,6 +72,16 @@
     "add_rights_button": "Legg til rettigheter",
     "add_no_rights_button": "Legg til rettigheter senere" 
   },
+  "authent_directconsentpage": {
+    "banner_title": "Gi tilgang til system",
+    "sub_title": "Visma AS ønsker å opprette en systemtilgang for Olsen Regnskap AS",
+    "consent_text": "Systembrukeren vil benyttes for behandling av data for Olsen Regnskap AS eller kunder av Olsen Regnskap AS.",
+    "consent_buttons_top_text": "Jeg samtykker til at:",
+    "add_consent_checkbox1": "Visma AS kan behandle data for Olsen Regnskap AS",
+    "add_consent_checkbox2": "Visma AS kan behandle data for kunder av Olsen Regnskap AS",
+    "add_consent_button1": "Ja, jeg gir samtykke",
+    "add_consent_button2": "Avbryt" 
+  },
   
   "authentication_dummy": {
     "auth_title_systembrukere": "Systembrukere",


### PR DESCRIPTION
## Description
The first iteration of the new design for DirectConsentPage 
from Slack post of 11.12.23 (also see Wiki Repo on Figma),
has been implemented.

## Related Issue(s)
- #135 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] User documentation is updated in Wiki Repo.
