### PR TITLE
Add Redux functionality to DirectConsentPage

### DIFF
--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { storeCheckbox1, storeCheckbox2 } from '@/rtk/features/directConsentPage/directConsentPageSlice';
 import { Button, Checkbox } from '@digdir/design-system-react';
 import { useEffect, useState } from 'react';
 import { useMediaQuery } from '@/resources/hooks';
@@ -10,47 +11,48 @@ import { useTranslation } from 'react-i18next';
 
 
 export const DirectConsentPageContent = () => {
-  const [saveDisabled, setSaveDisabled] = useState(false);
-  const [isEditable, setIsEditable] = useState(false);
+  const [checkbox1, setCheckbox1] = useState(false);
+  const [checkbox2, setCheckbox2] = useState(false);
+  // Fix-me: synchronize Redux state og local state
+  // const checkbox1State: boolean = useAppSelector((state) => state.directConsentPage.checkbox1);
+  // or just fix simple boolean reversion inside Reducer function: but 
+
   const { t } = useTranslation('common');
   const navigate = useNavigate();
   
-  const dispatch = useAppDispatch();
+  const dispatch = useAppDispatch(); // Redux for DirectConsentPage: design not ready
   const isSm = useMediaQuery('(max-width: 768px)');
 
   let overviewText: string;
   overviewText = t('authent_directconsentpage.sub_title'); // h2 below, not in Small/mobile view
 
-  // skal nå bare gå tilbake til OverviewPage
-  // selv om vi må vurdere en sletting av ting?
+  // for now, return to OverviewPage: design not ready
   const handleReject = () => {
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
-   // Mulig at her skal man trigge en dispatch
-  // og så navigere til OverviewPage
-  // har opprettet en creationPageSlice som nå er synlig i 
-  // Chrome DevTools --> må ut og løpe...
+  // possibly handleConfirm should be dependent on both checkboxes
+  // being checked... or perhaps ConfirmButton should be disabled
   const handleConfirm = () => {
     console.log("Her skulle det skjedd noe")
   }
 
   const handleCheck1 = () => {
-    console.log("Her skulle det skjedd noe")
+    // Fix-me: could probably simplify in Reducer itself
+    const invertedCheckbox1State: boolean = !checkbox1;
+    setCheckbox1(invertedCheckbox1State); // update local state
+    dispatch(storeCheckbox1( { checkbox1: invertedCheckbox1State} )); 
   }
 
   const handleCheck2 = () => {
-    console.log("Her skulle det skjedd noe")
+    // Fix-me: could probably simplify in Reducer itself
+    const invertedCheckbox2State: boolean = !checkbox2;
+    setCheckbox2(invertedCheckbox2State); // update local state
+    dispatch(storeCheckbox2( { checkbox1: invertedCheckbox2State} )); 
   }
 
-
-  // Fix-me: Må sette inn lag med Page, PageContainer etc... så det ligner
-  // på andre sider.
-
   return (
-
     <div className={classes.directConsentPageContainer}>
-
       <h2 className={classes.header}>{overviewText}</h2>
       <div className={classes.flexContainer}>
         <div className={classes.leftContainer}>
@@ -97,6 +99,7 @@ export const DirectConsentPageContent = () => {
                 color='primary'
                 size='small'
                 onClick={handleReject}
+                disabled={!checkbox1 || !checkbox2}
               >
                 {t('authent_directconsentpage.add_consent_button1')} 
               </Button> 

--- a/frontend/src/rtk/app/store.ts
+++ b/frontend/src/rtk/app/store.ts
@@ -4,6 +4,7 @@ import userInfoReducer from '../features/userInfo/userInfoSlice';
 import overviewPageReducer from '../features/overviewPage/overviewPageSlice';
 import creationPageReducer from '../features/creationPage/creationPageSlice';
 import maskinportenPageReducer from '../features/maskinportenPage/maskinportenPageSlice';
+import directConsentPageReducer from '../features/directConsentPage/directConsentPageSlice';
 
 const logger = createLogger();
 
@@ -15,6 +16,7 @@ const store = import.meta.env.PROD
         overviewPage: overviewPageReducer,
         creationPage: creationPageReducer,
         maskinportenPage: maskinportenPageReducer,
+        directConsentPage: directConsentPageReducer,
       },
     })
   : configureStore({
@@ -23,6 +25,7 @@ const store = import.meta.env.PROD
         overviewPage: overviewPageReducer,
         creationPage: creationPageReducer,
         maskinportenPage: maskinportenPageReducer,
+        directConsentPage: directConsentPageReducer,
       },
       middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware().concat(logger),

--- a/frontend/src/rtk/features/directConsentPage/directConsentPageSlice.ts
+++ b/frontend/src/rtk/features/directConsentPage/directConsentPageSlice.ts
@@ -1,0 +1,38 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export interface SliceState {
+  checkbox1: boolean;
+  checkbox2: boolean;
+  consentGiven: boolean
+}
+
+const initialState: SliceState = {
+    checkbox1: false,
+    checkbox2: false,
+    consentGiven: false,
+};
+
+// could just invert booleans instead of payload: but design is not final
+const directConsentPageSlice = createSlice({
+  name: 'directconsent',
+  initialState,
+  reducers: {
+    storeCheckbox1 : (state, action) => {
+        state.checkbox1 = action.payload.checkbox1;
+    },
+    storeCheckbox2 : (state, action) => {
+      state.checkbox2 = action.payload.checkbox2;
+    },
+    storeConsentGiven : (state, action) => {
+      state.consentGiven = action.payload.consentGiven;
+    },
+    clearStateAfterApi : (state) => {
+      state.checkbox1 = false;
+      state.checkbox2 = false;
+      state.consentGiven = false;
+    },
+  },
+});
+
+export default directConsentPageSlice.reducer;
+export const { storeCheckbox1, storeCheckbox2, storeConsentGiven, clearStateAfterApi } = directConsentPageSlice.actions;


### PR DESCRIPTION
## Description
As final design of page is not yet in,
the Redux functionality is only rudimentary.

Note that Confirm-button functionality assumes
that both checkboxes should be checked, but 
this could change.

## Related Issue(s)
- #135

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [X] User documentation is updated in Repo Wiki.
