### PR TITLE
Add HelpText component to CreationPage input field

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -6,7 +6,7 @@ import { AuthenticationPath } from '@/routes/paths';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { postNewSystemUser, CreationRequest, resetPostConfirmation } from '@/rtk/features/creationPage/creationPageSlice';
 import { fetchOverviewPage } from '@/rtk/features/overviewPage/overviewPageSlice';
-import { TextField, Button, Select } from '@digdir/design-system-react';
+import { TextField, Button, Select, HelpText } from '@digdir/design-system-react';
 import classes from './CreationPageContent.module.css';
 import { useMediaQuery } from '@/resources/hooks';
 
@@ -91,12 +91,20 @@ export const CreationPageContent = () => {
     <div className={classes.creationPageContainer}>
       <div className={classes.inputContainer}> 
         <div className={classes.nameWrapper}>
-            <TextField 
-              label = {t('authent_creationpage.input_field_label')} 
-              value = { integrationName }
-              onChange={e => setIntegrationName(e.target.value)}
-            />
+          <TextField 
+            label = {t('authent_creationpage.input_field_label')} 
+            value = { integrationName }
+            onChange={e => setIntegrationName(e.target.value)}
+          />   
         </div>
+        <div className={classes.nameWrapper}>
+          <HelpText
+            size="small"
+            title="Hjelpetekst for systembrukar"
+          >
+            Hjelpetekst for systembrukar
+          </HelpText>
+          </div>
       </div>
 
       <h2 className={classes.header}>{t('authent_creationpage.sub_title')}</h2>


### PR DESCRIPTION
## Description
The new design of 24.11.23 included a HelpText symbol
(question mark in circle)
in connection with the input field.

The Digdir Designsystem has such a component.

This component has now been tested out
on the CreationPage.

The exact text to be displayed upon activation
is not clear from design, and should be the topic 
of a future iteration.

## Related Issue(s)
- #138 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

