### PR TITLE
DirectConsentPage creates mock systemUser upon Confirm

### DIFF
--- a/frontend/src/features/directconsentpage/DirectConsentPage.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPage.tsx
@@ -1,24 +1,17 @@
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
-
 import { Page, PageHeader, PageContent, PageContainer } from '@/components';
 import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
 import { useMediaQuery } from '@/resources/hooks';
-
 import { DirectConsentPageContent } from './DirectConsentPageContent';
 
 export const DirectConsentPage = () => {
   const { t } = useTranslation('common');
   const isSm = useMediaQuery('(max-width: 768px)');
 
-  // fix-me: set language key in <PageHeader>
-
   return (
     <PageContainer>
-      <Page
-        color='dark'
-        size={isSm ? 'small' : 'medium'}
-      >
+      <Page color='dark' size={isSm ? 'small' : 'medium'} >
         <PageHeader icon={<ApiIcon />}>{t('authent_directconsentpage.banner_title')}</PageHeader>
         <PageContent>
           <DirectConsentPageContent />

--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { AuthenticationPath } from '@/routes/paths';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { storeCheckbox1, storeCheckbox2 } from '@/rtk/features/directConsentPage/directConsentPageSlice';
+import { postNewSystemUser, CreationRequest } from '@/rtk/features/creationPage/creationPageSlice';
 import { Button, Checkbox } from '@digdir/design-system-react';
 import { useEffect, useState } from 'react';
 import { useMediaQuery } from '@/resources/hooks';
@@ -31,10 +32,15 @@ export const DirectConsentPageContent = () => {
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
-  // possibly handleConfirm should be dependent on both checkboxes
-  // being checked... or perhaps ConfirmButton should be disabled
+  // confirm is a temporary solution, as backend and Maskinporten is not ready
+  // is to dispatch a mock systemUser object and return to OverviewPage
   const handleConfirm = () => {
-    console.log("Her skulle det skjedd noe")
+    const PostObjekt: CreationRequest = {
+      integrationTitle: "Direkte Tilgangsløsning",
+      selectedSystemType: "direct_consent_system : Direct Consent System",
+    };
+    void dispatch(postNewSystemUser(PostObjekt));  
+    navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Overview);
   }
 
   const handleCheck1 = () => {
@@ -87,13 +93,12 @@ export const DirectConsentPageContent = () => {
                 {t('authent_directconsentpage.add_consent_checkbox2')} 
               </Checkbox> 
             </div>
-
           </div>
+
           <br></br>
           <br></br>
 
           <div className={classes.buttonContainer}>
-
             <div className={classes.confirmButton}>
               <Button
                 color='primary'
@@ -103,9 +108,7 @@ export const DirectConsentPageContent = () => {
               >
                 {t('authent_directconsentpage.add_consent_button1')} 
               </Button> 
-              
             </div>
-
             <div className={classes.cancelButton}>
               <Button
                 color='primary'
@@ -115,11 +118,8 @@ export const DirectConsentPageContent = () => {
               >
                 {t('authent_directconsentpage.add_consent_button2')} 
               </Button> 
-               
             </div>
-
           </div>
-          
         </div>
       </div>
     </div>

--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
@@ -103,7 +103,7 @@ export const DirectConsentPageContent = () => {
               <Button
                 color='primary'
                 size='small'
-                onClick={handleReject}
+                onClick={handleConfirm}
                 disabled={!checkbox1 || !checkbox2}
               >
                 {t('authent_directconsentpage.add_consent_button1')} 


### PR DESCRIPTION
## Description
Until Maskinporten and Backend support for the Frontend solution is available, 
the DirectConsentPage navigates to OverviewPage upon Confirm, 
and a mock SystemUser object is posted ("Direkte Tilgangsløsning" etc), 
and appears in the list of SystemUsers in OverviewPage. 

Note this is a temporary solution, so that the (test) user gets 
some feedback upon completion in the present DirectConsentPage
(today the user is moved to OverviewPage, which does not show the
new directConsent systemUser he just agreed to...)

Also some general cleanup of code was performed.

## Related Issue(s)
- #135 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green


