### PR TITLE
Fix HelpText problem in narrow mobile view

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.module.css
+++ b/frontend/src/features/creationpage/CreationPageContent.module.css
@@ -103,7 +103,7 @@
   }
 
   .inputContainer {
-    flex-direction: column;
+    flex-direction: column-reverse;
   }
 
   .creationPageContainer {


### PR DESCRIPTION
## Description

<img width="485" alt="CreationPage_HelpText_MobileView_bug_screenshot_110124" src="https://github.com/Altinn/altinn-authentication-frontend/assets/94476391/0aff0307-dd76-4f07-95be-c9de0e237ea8">

This is why God created CSS.

## Related Issue(s)
- #138

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

