### PR TITLE
First iteration at collection array-of-rights inside CollectionBar array on OverviewPage

### DIFF
--- a/frontend/src/components/CollectionBar/CollectionBar.tsx
+++ b/frontend/src/components/CollectionBar/CollectionBar.tsx
@@ -40,13 +40,15 @@ export const CollectionBar = ({
   proceedToPath,
 }: CollectionBarProps) => {
   const { t } = useTranslation('common');
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
   // Edit Button is not used: but might be added back later
   const proceedClick = () => {
-    if (proceedToPath) {
-      navigate(proceedToPath);
-    }
+    console.log("User clicked on CollectionBar rights added hidden button");
+    
+    // if (proceedToPath) {
+    //  navigate(proceedToPath);
+    // }
   };
 
   // color of Rettigheter should be red or black, depending on external boolean
@@ -77,10 +79,10 @@ export const CollectionBar = ({
               variant='quiet'
               size='small'
               
-              color={"danger"}
+              color={"success"}
               onClick={proceedClick}
             >
-              XXX_fixme_{t('authent_overviewpage.rights_not_added')}
+              {t('authent_overviewpage.rights_added')}
             </Button>
           )
         }

--- a/frontend/src/components/CollectionBar/CollectionBar.tsx
+++ b/frontend/src/components/CollectionBar/CollectionBar.tsx
@@ -80,7 +80,7 @@ export const CollectionBar = ({
               color={"danger"}
               onClick={proceedClick}
             >
-              {t('authent_overviewpage.rights_not_added')}
+              XXX_fixme_{t('authent_overviewpage.rights_not_added')}
             </Button>
           )
         }

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -34,10 +34,8 @@ export const OverviewPageContent = () => {
   const { t } = useTranslation('common'); // not used yet
   const navigate = useNavigate();
 
-  // Fix-me: additionalText prop into CollectionBar is removed in Design of 24.11.23:
-  // set to empty string for now: if this persists the props should be reorganized
 
-  // Experiment 11.01.24: I need to find out what these bars do : code is from
+  // Experiment 11.01.24: CollectionBar should have collection: experiment with
   // AccMan repo: /src/features/singleRight/components/ResourceCollectionBar
 
   // this functional component selectedResourcesActionBars
@@ -52,32 +50,34 @@ export const OverviewPageContent = () => {
     console.log('handleClick');
   }; // Copilot
 
-  // used in CollectionBar below
-  const selectedResourcesActionBars = rightsObjektArray.map((ProductRight, index) => (
+  
+  // not used in ActionBar: but Button might be added back later
+  const ButtonPlaceholder = () => {
+    return (<></>)
+  };
+
+  // used in CollectionBar below: only use two key:value pairs, but is extendable
+  // based on AccMan repo: /src/features/singleRight/components/ResourceCollectionBar
+  // Button probably will not be used: but might be added back later
+  const selectedRightsActionBars = rightsObjektArray.map((ProductRight, index) => (
     <ActionBar
       key={index}
       title={ProductRight.right}
       subtitle={ProductRight.serviceProvider}
       size='small'
       color='success'
-      actions={
-        <Button
-          variant='filled'
-          size={compact ? 'medium' : 'small'}
-          onClick={handleClick}
-          icon={compact && <MinusCircleIcon title={t('common.remove')} />}
-        >
-          {!compact && t('common.remove')}
-        </Button>
-      }
+      actions={ButtonPlaceholder()}
     ></ActionBar>
   ));
 
 
-  // added pilot right collection ( from above, was [] before)
   // Note! CollectionBar has so far been hard-coded in component to
-  // say "Rettigheter ikke lagt til":
+  // say "Rettigheter ikke lagt til" --> now the opposite
   // but should probably be responsive to whether collection input is empty
+
+  // added pilot rights collection ( from above, was [] before)
+  // Also note that each SystemUser now has the same 3 rights
+  // ---> must be linked to real rights of a given SystemUser
   const reduxCollectionBarArray = () => {
     return reduxObjektArray.map( (SystemUser) => (
       <div key={SystemUser.id}>
@@ -86,15 +86,13 @@ export const OverviewPageContent = () => {
           subtitle= { `${SystemUser.productName}` }
           additionalText= {""} 
           color={'neutral'}
-          collection={selectedResourcesActionBars}
+          collection={selectedRightsActionBars}
           compact={isSm}
-          proceedToPath={ '/fixpath/' }
         />
       </div>
     ));
   };
   
-
   // Eldre greier: bør byttes ut, men kan trenges for Mobil-optimering
   const isSm = useMediaQuery('(max-width: 768px)'); // ikke i bruk lenger
 
@@ -106,12 +104,9 @@ export const OverviewPageContent = () => {
     navigate('/' + AuthenticationPath.Auth + '/' + AuthenticationPath.Creation);
   };
 
-
   return (
     <div className={classes.overviewPageContainer}>
-
       <h2 className={classes.pageContentText}>{overviewText}</h2>
-      
         <div className={classes.systemUserNewButton}>
           <Button
             variant='outline'
@@ -123,7 +118,6 @@ export const OverviewPageContent = () => {
             {t('authent_overviewpage.new_system_user_button')}
           </Button>
         </div>
-      
       <h2 className={classes.pageContentText}>
         {t('authent_overviewpage.existing_system_users_title')} 
       </h2>

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -4,8 +4,9 @@ import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { AuthenticationPath } from '@/routes/paths';
 import classes from './OverviewPageContent.module.css';
-import { CollectionBar } from '@/components';
+import { CollectionBar, ActionBar } from '@/components';
 import { ReactComponent as Add } from '@/assets/Add.svg';
+import { MinusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@digdir/design-system-react';
 import { useMediaQuery } from '@/resources/hooks';
 import { useTranslation } from 'react-i18next';
@@ -36,6 +37,47 @@ export const OverviewPageContent = () => {
   // Fix-me: additionalText prop into CollectionBar is removed in Design of 24.11.23:
   // set to empty string for now: if this persists the props should be reorganized
 
+  // Experiment 11.01.24: I need to find out what these bars do : code is from
+  // AccMan repo: /src/features/singleRight/components/ResourceCollectionBar
+
+  // this functional component selectedResourcesActionBars
+  // is fed into the collection prop of CollectionBar, which I have
+  // left empty so far. I hack resources to the new rights-array in Redux:
+  // systemRegisterProductsArray: used in RightsIncludedPage
+
+  const rightsObjektArray = useAppSelector((state) => state.rightsIncludedPage.systemRegisterProductsArray);
+
+  const compact: boolean = false; // not used yet
+  const handleClick = () => {
+    console.log('handleClick');
+  }; // Copilot
+
+  // used in CollectionBar below
+  const selectedResourcesActionBars = rightsObjektArray.map((ProductRight, index) => (
+    <ActionBar
+      key={index}
+      title={ProductRight.right}
+      subtitle={ProductRight.serviceProvider}
+      size='small'
+      color='success'
+      actions={
+        <Button
+          variant='filled'
+          size={compact ? 'medium' : 'small'}
+          onClick={handleClick}
+          icon={compact && <MinusCircleIcon title={t('common.remove')} />}
+        >
+          {!compact && t('common.remove')}
+        </Button>
+      }
+    ></ActionBar>
+  ));
+
+
+  // added pilot right collection ( from above, was [] before)
+  // Note! CollectionBar has so far been hard-coded in component to
+  // say "Rettigheter ikke lagt til":
+  // but should probably be responsive to whether collection input is empty
   const reduxCollectionBarArray = () => {
     return reduxObjektArray.map( (SystemUser) => (
       <div key={SystemUser.id}>
@@ -44,7 +86,7 @@ export const OverviewPageContent = () => {
           subtitle= { `${SystemUser.productName}` }
           additionalText= {""} 
           color={'neutral'}
-          collection={[]}
+          collection={selectedResourcesActionBars}
           compact={isSm}
           proceedToPath={ '/fixpath/' }
         />


### PR DESCRIPTION
## Description
The new Redux rights-array can be used to mock up
the missing rightsArray inside the list of SystemUsers
on the OverviewPage.

The first iteration should focus on handling the ActionBar properties
inside a CollectionBar array listed out by array.map() functions.

Some of the Design ideas seems to be that there should be a CollectionBar
inside the CollectionBar, but the ActionBar is easier to handle for the first pass.
And so far we have only had collection = {[]}

## Related Issue(s)
- #146 

The OverviewPage now looks like this:

<img width="879" alt="OverviewPage_rightsArray_inside_systemUserArray_screenshot_110124" src="https://github.com/Altinn/altinn-authentication-frontend/assets/94476391/5fd48b6c-70da-46b7-92ee-7c990b5a6a08">

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
