### PR TITLE
Building CollectionBar-inside-CollectionBar on OverviewPage, second pass on layered structure

### DIFF
--- a/frontend/src/features/overviewpage/OverviewPageContent.module.css
+++ b/frontend/src/features/overviewpage/OverviewPageContent.module.css
@@ -1,4 +1,15 @@
 
+.rightActionTagsWrapper {
+  display: flex;
+  justify-content: flex-left;
+  align-items: left;
+  margin-top: 0.5rem;
+}
+
+.tagSeparator {
+  margin-left: 0.5rem;
+}
+
 .spinnerContainer {
   margin-top: 3rem;
   display: flex;

--- a/frontend/src/features/overviewpage/OverviewPageContent.module.css
+++ b/frontend/src/features/overviewpage/OverviewPageContent.module.css
@@ -10,6 +10,11 @@
   margin-left: 0.5rem;
 }
 
+.middleLayerHeading {
+  font-size: 20px;
+  font-weight: 500;
+}
+
 .spinnerContainer {
   margin-top: 3rem;
   display: flex;

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -4,10 +4,10 @@ import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { AuthenticationPath } from '@/routes/paths';
 import classes from './OverviewPageContent.module.css';
-import { CollectionBar, ActionBar } from '@/components';
+import { CollectionBar } from '@/components';
 import { ReactComponent as Add } from '@/assets/Add.svg';
 import { MinusCircleIcon } from '@navikt/aksel-icons';
-import { Button } from '@digdir/design-system-react';
+import { Button, Tag } from '@digdir/design-system-react';
 import { useMediaQuery } from '@/resources/hooks';
 import { useTranslation } from 'react-i18next';
 import { resetPostConfirmation } from '@/rtk/features/creationPage/creationPageSlice';
@@ -34,59 +34,50 @@ export const OverviewPageContent = () => {
   const { t } = useTranslation('common'); // not used yet
   const navigate = useNavigate();
 
-
-  // Experiment 11.01.24: CollectionBar should have collection: experiment with
-  // AccMan repo: /src/features/singleRight/components/ResourceCollectionBar
-
-  // this functional component selectedResourcesActionBars
-  // is fed into the collection prop of CollectionBar, which I have
-  // left empty so far. I hack resources to the new rights-array in Redux:
-  // systemRegisterProductsArray: used in RightsIncludedPage
-
   const rightsObjektArray = useAppSelector((state) => state.rightsIncludedPage.systemRegisterProductsArray);
 
   const compact: boolean = false; // not used yet
-  const handleClick = () => {
-    console.log('handleClick');
-  }; // Copilot
 
-  
-  // not used in ActionBar: but Button might be added back later
-  const ButtonPlaceholder = () => {
-    return (<></>)
-  };
-
-  // mock array for ActionBar array below: not rendered correctly
-  // will access new currentRights API (see issue #8, no.8)
-  // This array should probably have two properties per line: right (read, right...)
-  // and a boolean on/off flag for whether it is active...
+  // INNERMOST LAYER of RightCollectionBar-inside-SystemUserCollectionBar setup
+  // mock array for ActionTags such as Read, Write, Sign etc: 
+  // *********API not ready************
+  // but should be flexible for future new actions, such as Rune´s Launch-Rocket
   const mockRightsActionsArray = [
-    {"right_action": "Lese"},
-    {"right_action": "Skrive"}, 
-    {"right_action": "Signere"},
-    {"right_action": "Les arkiv"}
+    { "name" : "Lese", "on" : true  },
+    { "name" : "Skrive", "on" : false },
+    { "name" : "Signere", "on" : true  },
+    { "name" : "Les arkiv", "on" : false },
+    { "name" : "Launch-Rune´s-Rocket", "on" : true }
   ];
 
-  // INNERMOST LAYER of CollectionBar-inside-CollectionBar setup: used as collection below
-  // ---> need to REWRITE COMPONENT for horizontal list of blue ovals
-  //  (or red depending on action available)
-  // ---> possibly AccMan has such a component already...
-  // ---> or Designsystemet ---> tar det på Mac i morgen...
-  // mangler også Info-tekst: subtitle={"Eventuell tekst om rettighetene kjem her."}
-  const mockRightActionBars = mockRightsActionsArray.map((mockRightsActions, index) => (
-    <ActionBar
-      key={index}
-      title={mockRightsActions.right_action}
-      size='small'
-      color='danger'
-      actions={ButtonPlaceholder()}
-    ></ActionBar>
+
+  // The Tags are mapped out of the mockRightsActionsArray 
+  const onlyTags = mockRightsActionsArray.map((mockRightsActions, index) => (
+    <div className={classes.tagSeparator}>
+      <Tag
+        key={index}
+        size="large"
+        color={ mockRightsActions.on ? "primary" : "danger" }
+      >{mockRightsActions.name}</Tag>
+    </div>
+    
   ));
+
+  // CollectionBar expects an array, som the Tags are wrapped as such
+  // and a explanatory text is added (Design not in yet)
+  const mockRightActionTags = [
+    <div>
+      <p>Eventuell tekst om rettighetene kommer her.</p>
+      <div className={classes.rightActionTagsWrapper}>  
+        {onlyTags}
+      </div>
+    </div>
+  ];
   
 
 
   // MIDDLE LAYER of RightCollectionBar-inside-SystemUserCollectionBar setup
-  // uses ActionBar-array inside collection
+  // consumes Tag-array as collection
   // also CollectionBar has hardcoded "Rettigheter lagt til" ---> probaby need custom CollectionBar
   // for this MIDDLE LAYER
   const currentRightsCollectionBars = rightsObjektArray.map((ProductRight, index) => (
@@ -95,10 +86,9 @@ export const OverviewPageContent = () => {
         title={ProductRight.right}
         subtitle={ProductRight.serviceProvider}
         color='success'
-        collection={mockRightActionBars}
+        collection={mockRightActionTags}
       ></CollectionBar>
     </div>
-    
   ));
 
 

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -35,7 +35,6 @@ export const OverviewPageContent = () => {
   const navigate = useNavigate();
 
   const rightsObjektArray = useAppSelector((state) => state.rightsIncludedPage.systemRegisterProductsArray);
-
   const compact: boolean = false; // not used yet
 
   // INNERMOST LAYER of RightCollectionBar-inside-SystemUserCollectionBar setup
@@ -63,7 +62,7 @@ export const OverviewPageContent = () => {
     
   ));
 
-  // CollectionBar expects an array, som the Tags are wrapped as such
+  // CollectionBar expects an array, so the Tags are wrapped as such
   // and a explanatory text is added (Design not in yet)
   const mockRightActionTags = [
     <div>
@@ -79,7 +78,8 @@ export const OverviewPageContent = () => {
   // MIDDLE LAYER of RightCollectionBar-inside-SystemUserCollectionBar setup
   // consumes Tag-array as collection
   // also CollectionBar has hardcoded "Rettigheter lagt til" ---> probaby need custom CollectionBar
-  // for this MIDDLE LAYER
+  // for this MIDDLE LAYER: bars should not have "Rettigheter lagt til"
+
   const currentRightsCollectionBars = rightsObjektArray.map((ProductRight, index) => (
     <div key={index}>
       <CollectionBar
@@ -91,8 +91,16 @@ export const OverviewPageContent = () => {
     </div>
   ));
 
-
-
+ 
+  // Add inner layer heading
+  const middleLayerCollectionBarWrapperArray = [
+    <div>
+      <h3 className={classes.middleLayerHeading}>
+        Systembrukeren har disse rettighetene:
+      </h3>
+      {currentRightsCollectionBars}
+    </div>
+  ];
 
   // OUTERMOST LAYER of RightCollectionBar-inside-SystemUserCollectionBar setup
   const reduxCollectionBarArray = () => {
@@ -103,7 +111,7 @@ export const OverviewPageContent = () => {
           subtitle= { `${SystemUser.productName}` }
           additionalText= {""} 
           color={'neutral'}
-          collection={currentRightsCollectionBars}
+          collection={middleLayerCollectionBarWrapperArray}
           compact={isSm}
         />
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We want to make each right-bar possible to open, and show the actual actions that are permitted (also see Design sketches of 5/12-23 via Repo Wiki Figma link,
the Design ideas seems to be that there should be a CollectionBar inside the CollectionBar).

The second pass of CollectionBar-inside-CollectionBar has been set up, 
where we add the rights as Designsystem Tags, in a row, with color, 
depending on whether the action (read, write, sign etc) is authorised or not.

## Related Issue(s)
- #148 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
