### PR TITLE
First Iteration of The DirectConsentPage should be a one-click-stop implementation

### DIFF
--- a/frontend/src/features/directconsentpage/DirectConsentPage.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPage.tsx
@@ -5,9 +5,33 @@ import { ReactComponent as ApiIcon } from '@/assets/Api.svg';
 import { useMediaQuery } from '@/resources/hooks';
 import { DirectConsentPageContent } from './DirectConsentPageContent';
 
+import { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { fetchOverviewPage } from '@/rtk/features/overviewPage/overviewPageSlice';
+import { fetchSystemRegisterVendors } from '@/rtk/features/creationPage/creationPageSlice';
+import { fetchSystemRegisterProducts } from '@/rtk/features/rightsIncludedPage/rightsIncludedPageSlice';
+
+
 export const DirectConsentPage = () => {
   const { t } = useTranslation('common');
   const isSm = useMediaQuery('(max-width: 768px)');
+  const dispatch = useAppDispatch();
+
+  // Transfer code from OverviewPage due to Redux reboot upon
+  // navigation to DirectConsentPage: Fix-me: dotnet app disturb?
+
+  const overviewLoaded = useAppSelector((state) => state.overviewPage.overviewLoaded);
+ 
+  // Fix-me: laster inn data bare en gang ved første render
+  // må finne mer elegant måte å gjøre dette på: og dynamisk: vil bare laste 1 gang
+  useEffect(() => {
+    if (!overviewLoaded) {
+      console.log("Førstegangs innlasting av OverviewPage og CreationPage data til Redux");
+      void dispatch(fetchOverviewPage());
+      void dispatch(fetchSystemRegisterVendors()); // for CreationPage
+      void dispatch(fetchSystemRegisterProducts()); // for RightsIncludedPage
+    }
+  }, []);
 
   return (
     <PageContainer>

--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
@@ -80,6 +80,12 @@ export const DirectConsentPageContent = () => {
     ));
   };
 
+  /* 
+            <p className={classes.contentText}>
+            {t('authent_directconsentpage.consent_buttons_top_text')}
+          </p>
+  */
+
   return (
     <div className={classes.directConsentPageContainer}>
       <h2 className={classes.header}>{overviewText}</h2>
@@ -90,38 +96,19 @@ export const DirectConsentPageContent = () => {
           {t('authent_directconsentpage.consent_text')}
           </p>
 
-          <br></br>
+          <br></br><br></br><br></br>
+
+          <h2 className={classes.header}>{t('authent_includedrightspage.sub_title')}</h2>
 
           <p className={classes.contentText}>
-          {t('authent_directconsentpage.consent_buttons_top_text')}
+            {t('authent_includedrightspage.content_text')}
           </p>
 
           <div className={classes.rightsArrayContainer}>
-            <p>XXX</p>
             { reduxRightsCollectionBarArray() }
           </div>
           
-          <div className={classes.checkboxContainer}>
-            <div className={classes.confirmButton}>
-              <Checkbox
-                color='primary'
-                size='small'
-                onClick={handleCheck1}
-              >
-                {t('authent_directconsentpage.add_consent_checkbox1')} 
-              </Checkbox> 
-            </div>
-
-            <div className={classes.confirmButton}>
-              <Checkbox
-                color='primary'
-                size='small'
-                onClick={handleCheck2}
-              >
-                {t('authent_directconsentpage.add_consent_checkbox2')} 
-              </Checkbox> 
-            </div>
-          </div>
+          
 
           <br></br>
           <br></br>
@@ -132,7 +119,6 @@ export const DirectConsentPageContent = () => {
                 color='primary'
                 size='small'
                 onClick={handleConfirm}
-                disabled={!checkbox1 || !checkbox2}
               >
                 {t('authent_directconsentpage.add_consent_button1')} 
               </Button> 

--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
@@ -97,6 +97,7 @@ export const DirectConsentPageContent = () => {
           </p>
 
           <div className={classes.rightsArrayContainer}>
+            <p>XXX</p>
             { reduxRightsCollectionBarArray() }
           </div>
           

--- a/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
+++ b/frontend/src/features/directconsentpage/DirectConsentPageContent.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { useMediaQuery } from '@/resources/hooks';
 import classes from './DirectConsentPageContent.module.css';
 import { useTranslation } from 'react-i18next';
+import { RightsCollectionBar } from '@/components';
 
 
 export const DirectConsentPageContent = () => {
@@ -57,6 +58,28 @@ export const DirectConsentPageContent = () => {
     dispatch(storeCheckbox2( { checkbox1: invertedCheckbox2State} )); 
   }
 
+  const reduxObjektArray = useAppSelector((state) => state.rightsIncludedPage.systemRegisterProductsArray);
+
+  // Note: array key set to ProductRight.right, which should be unique
+  // additionalText is not used yet
+  // and we probably need a CollectionBar without button at right side
+  const reduxRightsCollectionBarArray = () => {
+    return reduxObjektArray.map( (ProductRight) => (
+      <div key={ProductRight.right}>
+        <RightsCollectionBar
+          title=  {ProductRight.right}
+          subtitle= { `${ProductRight.serviceProvider}` }
+          additionalText= {""} 
+          color={'neutral'}
+          collection={[]}
+          compact={isSm}
+          proceedToPath={ '/fixpath/' }
+        />
+        <div className={classes.rightsSeparator} > </div>
+      </div>
+    ));
+  };
+
   return (
     <div className={classes.directConsentPageContainer}>
       <h2 className={classes.header}>{overviewText}</h2>
@@ -72,6 +95,10 @@ export const DirectConsentPageContent = () => {
           <p className={classes.contentText}>
           {t('authent_directconsentpage.consent_buttons_top_text')}
           </p>
+
+          <div className={classes.rightsArrayContainer}>
+            { reduxRightsCollectionBarArray() }
+          </div>
           
           <div className={classes.checkboxContainer}>
             <div className={classes.confirmButton}>


### PR DESCRIPTION
## Description
We will iterate over the DirectConsentPage again,
now with the aim of making it a one-click-stop,
for legal reasons,
but with listing of Rights signed away,
for legal reasons.

The RightsIncludedPage pattern has been followed.

The list of rights available in the API is now visible in the 
DirectConsentPage.

Also the Redux vs Router issue resurfaced in test,
thus future iterations should work more on solving this problem.

A temporary fix is that DirectConsentPage do dispatch itself.

There is also more polishing to be done.


## Related Issue(s)
- #154 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

