### PR TITLE
use alpine3.18 until we can upgrade to .NET 8 and alpine3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN yarn --immutable
 RUN yarn build
 
 #Building the Authentication BFF Backend
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS generate-authentication-backend
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS generate-authentication-backend
 COPY bff/src .
 RUN dotnet publish Altinn.Authentication.UI/Altinn.Authentication.UI/Altinn.Authentication.UI.csproj -c Release -r linux-x64 -o /app_output --no-self-contained 
 
 #Building the final image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS final
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine3.18 AS final
 EXPOSE 80
 #EXPOSE 443
 WORKDIR /app


### PR DESCRIPTION
## Description
As of 13.02.24, mcr.microsoft.com/dotnet/sdk:7.0 and mcr.microsoft.com/dotnet/aspnet:7.0 use alpine3.19, which does *not* include `libssl1.1`. This causes our docker build to fail. Temporary solution is to still use alpine3.18, but we should upgrade to alpine3.19 later (and libssl3)

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
