### PR TITLE
use the Party OrgNo instead of partyId in SystemUser since that is wh…

### DIFF
--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemRegister/DefaultRight.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemRegister/DefaultRight.cs
@@ -20,6 +20,6 @@
         /// <summary>
         /// The identifier for the Service Provider of the Resource.        
         /// </summary>
-        public string ServiceProvider { get; set; } = string.Empty;
+        public string ServiceProvider { get; set; } = "Skatteetaten";
     }
 }

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemUsers/ISystemUserClient.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemUsers/ISystemUserClient.cs
@@ -3,7 +3,7 @@
 public interface ISystemUserClient
 {
     Task<SystemUser?> GetSpecificSystemUserReal(int partyId, Guid id, CancellationToken cancellationToken = default);
-    Task<SystemUser?> PostNewSystemUserReal(int partyId, SystemUserDescriptor newSystemUserDescriptor, CancellationToken cancellation = default);
+    Task<SystemUser?> PostNewSystemUserReal(string partyOrgNo, SystemUserDescriptor newSystemUserDescriptor, CancellationToken cancellation = default);
     Task<bool> DeleteSystemUserReal(Guid id, CancellationToken cancellationToken = default);
     Task<bool> ChangeSystemUserRealTitle(string newTitle, Guid id, CancellationToken cancellationToken = default);
     Task<bool> ChangeSystemUserRealDescription(string newDescr, Guid id, CancellationToken cancellationToken = default);

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemUsers/SystemUser.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemUsers/SystemUser.cs
@@ -46,6 +46,11 @@ public class SystemUser
     public string OwnedByPartyId { get; set; } = string.Empty;
 
     /// <summary>
+    /// The Organisation number for the end-user Organisation.         
+    /// </summary>
+    [JsonPropertyName("ownedByOrgNo")]
+    public string OwnedByOrgNo { get; set; } = string.Empty;
+    /// <summary>
     /// Nice to have for debugging and logging.
     /// </summary>
     [JsonPropertyName("created")]

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemUsers/SystemUserService.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Core/SystemUsers/SystemUserService.cs
@@ -1,12 +1,19 @@
-﻿namespace Altinn.Authentication.UI.Core.SystemUsers;
+﻿using Altinn.Authentication.UI.Core.UserProfiles;
+using Altinn.Platform.Register.Models;
+
+namespace Altinn.Authentication.UI.Core.SystemUsers;
 
 public class SystemUserService : ISystemUserService
 {
     private readonly ISystemUserClient _systemUserClient;
+    private readonly IPartyClient _partyLookUpClient;
 
-    public SystemUserService(ISystemUserClient systemUserClient)
+    public SystemUserService(
+        ISystemUserClient systemUserClient,
+        IPartyClient partyLookUpClient)
     {
         _systemUserClient = systemUserClient;
+        _partyLookUpClient = partyLookUpClient;
     }
 
     public async Task<bool> ChangeSystemUserDescription(string newDescr, Guid id, CancellationToken cancellationToken = default)
@@ -27,11 +34,6 @@ public class SystemUserService : ISystemUserService
     public async Task<List<SystemUser>> GetAllSystemUserDTOsForChosenUser(int id, CancellationToken cancellationToken = default)
     {
         var lista = await _systemUserClient.GetSystemUserRealsForChosenUser(id, cancellationToken);
-        //List<SystemUserDTO> listofDTOs = new();
-        //foreach(var sur in listofReal) {
-        //    var dto = MapFromSystemUserRealToDTO(sur);
-        //    if (dto is not null)  listofDTOs.Add(dto); 
-        //}
         return lista;
     }
 
@@ -41,28 +43,11 @@ public class SystemUserService : ISystemUserService
         return await _systemUserClient.GetSpecificSystemUserReal(partyId, id, cancellationToken);
     }
 
-    private static SystemUserDTO? MapFromSystemUserRealToDTO(SystemUserReal? systemUserReal)
-    {
-        if (systemUserReal is null) return null;
-        SystemUserDTO systemUserDTO = new()
-        {
-            IntegrationTitle = systemUserReal.Title,
-            Description = systemUserReal.Description,
-            Created = systemUserReal.Created,
-            // ClientId = systemUserReal.ClientId,//Not a deliverable in the first Phase of the Project
-            ProductName = systemUserReal.SystemType,
-            SupplierName = "Not implemented yet",
-            SupplierOrgno = "999999999MVA", 
-            Id = systemUserReal.Id,
-            OwnedByPartyId = systemUserReal.OwnedByPartyId,
-        };
-
-        return systemUserDTO;
-    }
-
     public async Task<SystemUser?> PostNewSystemUserDescriptor(int partyId, SystemUserDescriptor newSystemUserDescriptor, CancellationToken cancellation = default)
     {
-        return await _systemUserClient.PostNewSystemUserReal(partyId, newSystemUserDescriptor, cancellation);
+        Party party = await _partyLookUpClient.GetPartyFromReporteeListIfExists(partyId);
+        string partyOrgNo = party.OrgNumber; 
+        return await _systemUserClient.PostNewSystemUserReal(partyOrgNo, newSystemUserDescriptor, cancellation);
     }
 
     public async Task<bool> ChangeSystemUserProduct(string selectedSystemType, Guid id, CancellationToken cancellationToken = default)

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Integration/SystemUsers/SystemUserClient.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Integration/SystemUsers/SystemUserClient.cs
@@ -63,18 +63,17 @@ public class SystemUserClient : ISystemUserClient
     }
 
     public async Task<SystemUser?> PostNewSystemUserReal(
-        int partyId,
+        string partyOrgNo,
         SystemUserDescriptor newSystemUserDescriptor, 
         CancellationToken cancellation = default)
-    {
-        if(partyId.ToString() != newSystemUserDescriptor.OwnedByPartyId) { return null; }
+    {      
 
         string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext!, _platformSettings.JwtCookieName!)!;
-        string endpointUrl = $"systemuser/{partyId}";
+        string endpointUrl = $"systemuser/{partyOrgNo}";
         var accessToken = await _accessTokenProvider.GetAccessToken();
         var requestObject = new
         { 
-            PartyId = partyId,
+            PartyId = newSystemUserDescriptor.OwnedByPartyId ?? string.Empty,
             IntegrationTitle = newSystemUserDescriptor.IntegrationTitle!,
             ProductName = newSystemUserDescriptor.SelectedSystemType!            
         };

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Mocks/Mocks/SystemUsers/SystemUserClientMock.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Mocks/Mocks/SystemUsers/SystemUserClientMock.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.Authentication.UI.Core.SystemUsers;
+using Altinn.Authentication.UI.Core.UserProfiles;
 
 namespace Altinn.Authentication.UI.Mocks.SystemUsers;
 
@@ -58,6 +59,7 @@ public class SystemUserClientMock : ISystemUserClient
     }
 
     private readonly HttpClient _httpClient;
+    private readonly IPartyClient _partyClient;
     private static List<SystemUser> _systemUserList = [];
 
     private static SystemUserReal MapDescriptorToSystemUserReal(SystemUserDescriptor sysdescr)
@@ -73,8 +75,9 @@ public class SystemUserClientMock : ISystemUserClient
         };       
     }
 
-    public SystemUserClientMock(HttpClient httpClient)
+    public SystemUserClientMock(HttpClient httpClient, IPartyClient partyClient)
     {
+        _partyClient = partyClient;
         _httpClient = httpClient;
         _systemUserList = MockTestHelperNew();
     }

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Mocks/Mocks/SystemUsers/SystemUserClientMock.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Mocks/Mocks/SystemUsers/SystemUserClientMock.cs
@@ -85,7 +85,7 @@ public class SystemUserClientMock : ISystemUserClient
         return _systemUserList.Find(i => i.Id == id.ToString());
     }
 
-    public async Task<SystemUser> PostNewSystemUserReal(int partyId, SystemUserDescriptor newSystemUserDescriptor, CancellationToken cancellation = default)
+    public async Task<SystemUser> PostNewSystemUserReal(string partyOrgNo, SystemUserDescriptor newSystemUserDescriptor, CancellationToken cancellation = default)
     {
         await Task.Delay(50);
         //var sysreal = MapDescriptorToSystemUserReal(newSystemUserDescriptor);

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Tests/Clients/SystemUserClientTest.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Tests/Clients/SystemUserClientTest.cs
@@ -1,7 +1,9 @@
 ﻿using Altinn.Authentication.UI.Controllers;
 using Altinn.Authentication.UI.Core.SystemUsers;
 using Altinn.Authentication.UI.Integration.SystemUsers;
+using Altinn.Authentication.UI.Integration.UserProfiles;
 using Altinn.Authentication.UI.Mocks.SystemUsers;
+using Altinn.Authentication.UI.Mocks.UserProfiles;
 using Altinn.Authentication.UI.Tests.Utils;
 using Xunit;
 
@@ -18,7 +20,8 @@ public class SystemUserClientIntegrationTest : IClassFixture<CustomWebApplicatio
     public SystemUserClientIntegrationTest()
     {
         _systemUserClient = new SystemUserClientMock(
-            new HttpClient{BaseAddress = new UriBuilder("https://localhost:44377/").Uri});
+            new HttpClient {BaseAddress = new UriBuilder("https://localhost:44377/").Uri},
+            new PartyClientMock ());
     }
 
     [Fact]
@@ -42,7 +45,7 @@ public class SystemUserClientIntegrationTest : IClassFixture<CustomWebApplicatio
     public async Task CreateSystemUser_ReturnOk()
     {
         var usr = await _systemUserClient.PostNewSystemUserReal(
-            1,
+            "1",
             new SystemUserDescriptor 
             { 
                 OwnedByPartyId = "1",

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Tests/Controllers/SystemUserControllerTest.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Tests/Controllers/SystemUserControllerTest.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Net.Http.Headers;
 using System.Security.Policy;
 using Xunit;
+using Altinn.Authentication.UI.Mocks.UserProfiles;
 
 namespace Altinn.Authentication.UI.Tests.Controllers;
 
@@ -25,7 +26,7 @@ public class SystemUserControllerTest :IClassFixture<CustomWebApplicationFactory
     {
         _factory = factory;
         _client = SetupUtils.GetTestClient(factory);
-        _systemUserService = new SystemUserService(new SystemUserClientMock(_client));
+        _systemUserService = new SystemUserService(new SystemUserClientMock(_client, new PartyClientMock()), new PartyClientMock());
     }
 
     [Fact]

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI/Controllers/SystemUserController.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI/Controllers/SystemUserController.cs
@@ -122,20 +122,7 @@ public class SystemUserController : ControllerBase
         newSystemUserDescriptor.OwnedByPartyId = partyId.ToString();
         var usr = await _systemUserService.PostNewSystemUserDescriptor(partyId, newSystemUserDescriptor, cancellationToken);
         if (usr is not null)
-        {
-            //SystemUserDTO dto = new() 
-            //{
-            //    Id = usr.Id,
-            //    IntegrationTitle = usr.Title,
-            //    ClientId = usr.ClientId,
-            //    Created = usr.Created,
-            //    Description = usr.Description,
-            //    OwnedByPartyId = usr.OwnedByPartyId,
-            //    ProductName = usr.SystemType,
-            //    ServiceOwner = "",
-            //    SupplierName = "",
-            //    SupplierOrgno = ""
-            //};
+        {           
             return Ok(usr);
         }
 


### PR DESCRIPTION
## Description
use the Party OrgNo instead of partyId in SystemUser since that is what Maskinporten uses
