### PR TITLE
Remove name field from systemuser v1 creation wizard

### DIFF
--- a/frontend/src/features/creationpage/CreationPageContent.tsx
+++ b/frontend/src/features/creationpage/CreationPageContent.tsx
@@ -1,19 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import {
-  Textfield,
-  Button,
-  Heading,
-  Combobox,
-  Alert,
-  Paragraph,
-} from '@digdir/designsystemet-react';
+import { Button, Heading, Combobox, Alert, Paragraph } from '@digdir/designsystemet-react';
 import { AuthenticationRoute } from '@/routes/paths';
 import classes from './CreationPageContent.module.css';
 import { useGetVendorsQuery } from '@/rtk/features/systemUserApi';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { setIntegrationTitle, setSelectedSystemType } from '@/rtk/features/createSystemUserSlice';
+import { setSelectedSystemType } from '@/rtk/features/createSystemUserSlice';
 
 export const CreationPageContent = () => {
   const { t } = useTranslation();
@@ -36,21 +29,8 @@ export const CreationPageContent = () => {
     navigate(AuthenticationRoute.RightsIncluded);
   };
 
-  const isNameTooLong = integrationTitle.length > 255;
-
   return (
     <div className={classes.creationPageContainer}>
-      <div className={classes.inputContainer}>
-        <Textfield
-          label={t('authent_creationpage.input_field_label')}
-          value={integrationTitle}
-          onChange={(e) => dispatch(setIntegrationTitle(e.target.value))}
-          error={
-            isNameTooLong &&
-            t('authent_creationpage.name_too_long', { nameLength: integrationTitle.length })
-          }
-        />
-      </div>
       <div>
         <Heading level={2} size='small' spacing>
           {t('authent_creationpage.sub_title')}
@@ -65,7 +45,13 @@ export const CreationPageContent = () => {
           placeholder={t('common.choose')}
           onValueChange={(newValue: string[]) => {
             if (newValue?.length) {
-              dispatch(setSelectedSystemType(newValue[0]));
+              const system = vendors?.find((x) => x.systemTypeId === newValue[0]);
+              dispatch(
+                setSelectedSystemType({
+                  systemId: newValue[0],
+                  friendlySystemName: system?.friendlyProductName ?? '',
+                }),
+              );
             }
           }}
           value={selectedSystemType ? [selectedSystemType] : undefined}
@@ -91,7 +77,7 @@ export const CreationPageContent = () => {
           variant='primary'
           size='small'
           onClick={handleConfirm}
-          disabled={!integrationTitle.trim() || !selectedSystemType || isNameTooLong}
+          disabled={!integrationTitle.trim() || !selectedSystemType}
         >
           {t('authent_creationpage.confirm_button')}
         </Button>

--- a/frontend/src/features/detailpage/DetailPageContent.tsx
+++ b/frontend/src/features/detailpage/DetailPageContent.tsx
@@ -43,7 +43,9 @@ export const DetailPageContent = ({ systemUser }: DetailPageContentProps) => {
           })}
         </Modal.Content>
         {isDeleteError && (
-          <Alert severity='danger'>{t('authent_detailpage.delete_systemuser_error')}</Alert>
+          <Alert severity='danger' role='alert'>
+            {t('authent_detailpage.delete_systemuser_error')}
+          </Alert>
         )}
         <Modal.Footer>
           <Button
@@ -79,7 +81,9 @@ export const DetailPageContent = ({ systemUser }: DetailPageContentProps) => {
         error={isNameTooLong && t('authent_detailpage.name_too_long', { nameLength: name.length })}
       />
       {isUpdateError && (
-        <Alert severity='danger'>{t('authent_detailpage.update_systemuser_error')}</Alert>
+        <Alert severity='danger' role='alert'>
+          {t('authent_detailpage.update_systemuser_error')}
+        </Alert>
       )}
       <div>
         <div className={classes.buttonContainer}>

--- a/frontend/src/features/overviewpage/OverviewPageContent.tsx
+++ b/frontend/src/features/overviewpage/OverviewPageContent.tsx
@@ -8,7 +8,7 @@ import { useFirstRenderEffect } from '@/resources/hooks';
 import { useTranslation } from 'react-i18next';
 import { useGetSystemUsersQuery } from '@/rtk/features/systemUserApi';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { setIntegrationTitle, setSelectedSystemType } from '@/rtk/features/createSystemUserSlice';
+import { setSelectedSystemType } from '@/rtk/features/createSystemUserSlice';
 import { SystemUserActionBar } from '@/components/SystemUserActionBar';
 
 export const OverviewPageContent = () => {
@@ -27,8 +27,7 @@ export const OverviewPageContent = () => {
 
   // reset create wizard values when overviewPage is rendered; the user ends up here after create, cancel or back navigation
   useFirstRenderEffect(() => {
-    dispatch(setIntegrationTitle(''));
-    dispatch(setSelectedSystemType(''));
+    dispatch(setSelectedSystemType({ systemId: '', friendlySystemName: '' }));
   });
 
   const goToStartNewSystemUser = () => {

--- a/frontend/src/features/rightsincludedpage/RightsIncludedPageContent.tsx
+++ b/frontend/src/features/rightsincludedpage/RightsIncludedPageContent.tsx
@@ -76,7 +76,9 @@ export const RightsIncludedPageContent = () => {
       <div>
         <RightsList rights={vendor?.defaultRights ?? []} />
         {isCreateSystemUserError && (
-          <Alert severity='danger'>{t('authent_includedrightspage.create_systemuser_error')}</Alert>
+          <Alert severity='danger' role='alert'>
+            {t('authent_includedrightspage.create_systemuser_error')}
+          </Alert>
         )}
         <div className={classes.buttonContainer}>
           <Button

--- a/frontend/src/localizations/en.json
+++ b/frontend/src/localizations/en.json
@@ -14,7 +14,7 @@
     "banner_title": "Manage system access",
     "sub_title": "Create a system access",
     "sub_title_text": "By creating a system access, you give a vendor system access to solve tasks in Altinn on behalf of your company.",
-    "systemusers_load_error": "Failed to load system access",
+    "systemusers_load_error": "Failed to load system accesses",
     "new_system_user_button": "Create new system access",
     "new_first_system_user_button": "Create system access",
     "existing_earlier_system_users_title": "Previously created system accesses:",

--- a/frontend/src/localizations/no_nb.json
+++ b/frontend/src/localizations/no_nb.json
@@ -14,7 +14,7 @@
     "banner_title": "Administrere systemtilgang",
     "sub_title": "Lag en systemtilgang",
     "sub_title_text": "Ved å opprette en systemtilgang gir du et fagsystem tilgang til å løse oppgaver i Altinn på vegne av bedriften din.",
-    "systemusers_load_error": "Kunne ikke laste systemtilgang",
+    "systemusers_load_error": "Kunne ikke laste systemtilganger",
     "new_system_user_button": "Lag ny systemtilgang",
     "new_first_system_user_button": "Lag systemtilgang",
     "existing_earlier_system_users_title": "Tidligere opprettede systemtilganger:",

--- a/frontend/src/localizations/no_nn.json
+++ b/frontend/src/localizations/no_nn.json
@@ -14,7 +14,7 @@
     "banner_title": "Administrera systemtilgangar",
     "sub_title": "Her kan du administrera dine systemtilgangar",
     "sub_title_text": "Ved å oppretta ein systemtilgang gir du eit fagsystem tilgang til å løysa oppgåver i Altinn på vegne av bedrifta di.",
-    "systemusers_load_error": "Kunne ikkje laste systemtilgang",
+    "systemusers_load_error": "Kunne ikkje laste systemtilgangar",
     "new_system_user_button": "Lag ny systemtilgang",
     "new_first_system_user_button": "Lag systemtilgang",
     "existing_earlier_system_users_title": "Tidlegare oppretta systemtilgangar:",

--- a/frontend/src/rtk/features/createSystemUserSlice.ts
+++ b/frontend/src/rtk/features/createSystemUserSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 export interface CreateSystemUserState {
   integrationTitle: string;
@@ -16,18 +16,18 @@ const createSystemUserSlice = createSlice({
   name: 'createSystemUserSlice',
   initialState,
   reducers: {
-    setIntegrationTitle: (state, action: { payload: string }) => {
-      state.integrationTitle = action.payload;
+    setSelectedSystemType: (
+      state,
+      action: PayloadAction<{ systemId: string; friendlySystemName: string }>,
+    ) => {
+      state.selectedSystemType = action.payload.systemId;
+      state.integrationTitle = action.payload.friendlySystemName;
     },
-    setSelectedSystemType: (state, action: { payload: string }) => {
-      state.selectedSystemType = action.payload;
-    },
-    setCreatedId: (state, action: { payload: string }) => {
+    setCreatedId: (state, action: PayloadAction<string>) => {
       state.newlyCreatedId = action.payload;
     },
   },
 });
 
 export default createSystemUserSlice.reducer;
-export const { setIntegrationTitle, setSelectedSystemType, setCreatedId } =
-  createSystemUserSlice.actions;
+export const { setSelectedSystemType, setCreatedId } = createSystemUserSlice.actions;


### PR DESCRIPTION
## Description
- Remove name field from creation wizard. Name is instead set to chosen system name
- Add role="alert" to error messages based on user input (on error when creating, deleting or updating systemuser)
- Fix typo in error message

## Related Issue(s)
- #301 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
