### PR TITLE
Enable corepack in Playwright tests 

### DIFF
--- a/.github/workflows/template-test-playwright.yml
+++ b/.github/workflows/template-test-playwright.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Enable Corepack to use yarn version > 1
+        run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*


### PR DESCRIPTION
## Description

We currently use yarn 4.3.1 for running the Playwright tests, but the newest yarn version in npm is 1.22.22. We need to enable corepack to be able to download and use yarn 4.3.1 to run the Playwright tests. In yarn v4, using corepack is considered best practice instead of including yarn binary in repo (https://yarnpkg.com/blog/release/4.0).

## Related Issue(s)
- #323 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
