### PR TITLE
Fix unique file path for Playwright artifact upload

### DIFF
--- a/.github/workflows/template-test-playwright.yml
+++ b/.github/workflows/template-test-playwright.yml
@@ -28,8 +28,8 @@ jobs:
         working-directory: frontend/playwright
         run: yarn run env:${{ inputs.environment }}
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: playwright-report
-          path: frontend/playwright/test-results
+          path: frontend/playwright/test-results/${{ inputs.environment }}
           retention-days: 30


### PR DESCRIPTION
## Description
- Artifact path should be unique to avoid conflicts when trying to save second Playwright test result artifact
- Only save artifact on test failure

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
