### PR TITLE
Store playwright artifacts in separate folders for each test environment

### DIFF
--- a/frontend/playwright/playwright.config.ts
+++ b/frontend/playwright/playwright.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       },
     ],
   ],
+  outputDir: `test-results/${process.env.environment ?? 'at22'}`,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     headless: true,

--- a/frontend/playwright/playwright.config.ts
+++ b/frontend/playwright/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       },
     ],
   ],
-  outputDir: `frontend/playwright/test-results/${process.env.environment?.toLowerCase() ?? 'at22'}`,
+  outputDir: `frontend/playwright/test-results/${process.env.environment?.toUpperCase() ?? 'at22'}`,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     headless: true,

--- a/frontend/playwright/playwright.config.ts
+++ b/frontend/playwright/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       },
     ],
   ],
-  outputDir: `test-results/${process.env.environment ?? 'at22'}`,
+  outputDir: `frontend/playwright/test-results/${process.env.environment?.toLowerCase() ?? 'at22'}`,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     headless: true,

--- a/frontend/playwright/playwright.config.ts
+++ b/frontend/playwright/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       },
     ],
   ],
-  outputDir: `frontend/playwright/test-results/${process.env.environment?.toUpperCase() ?? 'at22'}`,
+  outputDir: `test-results/${process.env.environment?.toUpperCase() ?? 'at22'}`,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     headless: true,

--- a/frontend/playwright/playwright.config.ts
+++ b/frontend/playwright/playwright.config.ts
@@ -8,7 +8,7 @@ enum TestNames {
 }
 
 dotenv.config({
-  path: path.resolve(__dirname, `config/.env.${process.env.environment ?? 'at22'}`),
+  path: path.resolve(__dirname, `config/.env.${process.env.environment ?? 'AT22'}`),
 });
 
 /**
@@ -32,7 +32,7 @@ export default defineConfig({
       },
     ],
   ],
-  outputDir: `test-results/${process.env.environment?.toUpperCase() ?? 'at22'}`,
+  outputDir: `test-results/${process.env.environment?.toUpperCase() ?? 'AT22'}`,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     headless: true,


### PR DESCRIPTION
## Description
Otherwise, using `test-results` folder for all test environments will only work for the first test environment tests fail in

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
