### PR TITLE
Dont try to deserialize resource if it is not found

### DIFF
--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Integration/SystemRegister/ResourceRegistryClient.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI.Integration/SystemRegister/ResourceRegistryClient.cs
@@ -32,8 +32,15 @@ public class ResourceRegistryClient : IResourceRegistryClient
             string endpointUrl = $"resource/{resourceId}";
 
             HttpResponseMessage response = await _httpClient.GetAsync(endpointUrl, cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.OK) 
+            {
+                return await response.Content.ReadFromJsonAsync<ServiceResource>(_jsonSerializerOptions, cancellationToken);
+            }
+            else 
+            {
+                return null;
+            }
 
-            return await response.Content.ReadFromJsonAsync<ServiceResource>(_jsonSerializerOptions, cancellationToken);
 
         }
         catch (Exception ex)


### PR DESCRIPTION
## Description
If a resource registered as a system right does not exists in resource registry, set serviceResource to null, instead of trying to deserialize `NoContent` as a resource

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
