### PR TITLE
Do not run Playwright tests in AT21

### DIFF
--- a/.github/workflows/build-deploy-at.yml
+++ b/.github/workflows/build-deploy-at.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [AT21, AT22]
+        environment: [AT22]
     uses: "./.github/workflows/template-test-playwright.yml"
     with:
       environment: ${{ matrix.environment }}


### PR DESCRIPTION
## Description
As the tests always fail in AT21, do not run Playwright tests in AT21

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
