### PR TITLE
Bugfix: use org partyId when deleting system user

### DIFF
--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI/Controllers/SystemUserController.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI/Controllers/SystemUserController.cs
@@ -158,7 +158,7 @@ public class SystemUserController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
     {
-        int partyId = AuthenticationHelper.GetUsersPartyId(_httpContextAccessor.HttpContext!);
+        int partyId = AuthenticationHelper.GetRepresentingPartyId(_httpContextAccessor.HttpContext!);
         var toBeDeleted = await _systemUserService.GetSpecificSystemUserDTO(partyId, id, cancellationToken);
         if (toBeDeleted == null) return NotFound();
         if (partyId.ToString() != toBeDeleted.PartyId) return BadRequest();

--- a/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI/Controllers/SystemUserController.cs
+++ b/bff/src/Altinn.Authentication.UI/Altinn.Authentication.UI/Controllers/SystemUserController.cs
@@ -26,15 +26,13 @@ namespace Altinn.Authentication.UI.Controllers;
 public class SystemUserController : ControllerBase
 {
     ISystemUserService _systemUserService;
-    IHttpContextAccessor _httpContextAccessor;
 
     /// <summary>
     /// Constructor for <see cref="SystemUserController"/>
     /// </summary>
-    public SystemUserController(ISystemUserService systemUserService, IHttpContextAccessor httpContextAccessor)
+    public SystemUserController(ISystemUserService systemUserService)
     {
         _systemUserService = systemUserService;
-        _httpContextAccessor = httpContextAccessor;
     }
     
     /// <summary>
@@ -158,7 +156,8 @@ public class SystemUserController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
     {
-        int partyId = AuthenticationHelper.GetRepresentingPartyId(_httpContextAccessor.HttpContext!);
+        // Get the partyId from the context (Altinn Part Coook)
+        int partyId = AuthenticationHelper.GetRepresentingPartyId(HttpContext);
         var toBeDeleted = await _systemUserService.GetSpecificSystemUserDTO(partyId, id, cancellationToken);
         if (toBeDeleted == null) return NotFound();
         if (partyId.ToString() != toBeDeleted.PartyId) return BadRequest();


### PR DESCRIPTION
## Description
- Use org partyId instead of user partyId when deleting system user
- Refactor: use `HttpContext` instead of `_httpContextAccessor.HttpContext`

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
