### PR TITLE
Keep lodaded Systemvendors in frontend cache

### DIFF
--- a/frontend/src/rtk/features/systemUserApi.ts
+++ b/frontend/src/rtk/features/systemUserApi.ts
@@ -26,6 +26,7 @@ export const systemUserApi = apiWithTag.injectEndpoints({
     getVendors: builder.query<VendorSystem[], void>({
       query: () => `/systemregister`,
       providesTags: [Tags.VendorSystems],
+      keepUnusedDataFor: Infinity,
     }),
     getSystemRights: builder.query<ServiceResource[], string>({
       query: (systemId) => url`systemregister/rights/${systemId}`,


### PR DESCRIPTION
## Description
- Do not empty systemvendor cache when dropdown component is unmounted

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
