### PR TITLE
remove deletion step from test, more unique names + proper cleanup of systems for Playwright tests

### DIFF
--- a/frontend/playwright/api-requests/ApiRequests.tsx
+++ b/frontend/playwright/api-requests/ApiRequests.tsx
@@ -183,8 +183,8 @@ export class ApiRequests {
 
   public async createSystemSystemRegister(): Promise<string> {
     const vendorId = process.env.ORG;
-    const clientId = `Client_${Date.now()}`;
-    const name = `AE2E-${Date.now()}`;
+    const clientId = `Client_${Date.now()}` + Math.random();
+    const name = `AE2E-${Date.now()}` + Math.random();
 
     const payload = {
       Id: `${vendorId}_${name}`,

--- a/frontend/playwright/e2eTests/selectSystemVendor.spec.ts
+++ b/frontend/playwright/e2eTests/selectSystemVendor.spec.ts
@@ -3,19 +3,26 @@ import { SystemUserPage } from '../pages/systemUserPage';
 import { TestdataApi } from 'playwright/util/TestdataApi';
 import { ApiRequests } from 'playwright/api-requests/ApiRequests';
 
-test('Create system user and verify landing page', async ({ page }): Promise<void> => {
-  //Make sure system user does not exist first
-  const api: ApiRequests = new ApiRequests();
 
-  await TestdataApi.removeAllSystemUsers();
-  const system = await api.createSystemSystemRegister();
+test.describe('System Register', async () => {
+  let system: string;
 
-  const systemUserPage = new SystemUserPage(page);
-  await systemUserPage.selectSystem(system);
-  await systemUserPage.CREATE_SYSTEM_USER_BUTTON.click();
-  await expect(systemUserPage.SYSTEMUSER_CREATED_HEADING).toBeVisible();
-  await expect(page.getByText(system).first()).toBeVisible();
+  test.beforeEach(async () => {
+    const api = new ApiRequests();
+    system = await api.createSystemSystemRegister(); // Create system before each test
+  });
 
-  //Cleanup
-  await TestdataApi.removeSystem(system);
+  test('Create system user and verify landing page', async ({ page }): Promise<void> => {
+    const systemUserPage = new SystemUserPage(page);
+    await systemUserPage.selectSystem(system);
+    await systemUserPage.CREATE_SYSTEM_USER_BUTTON.click();
+    await expect(systemUserPage.SYSTEMUSER_CREATED_HEADING).toBeVisible();
+    await expect(page.getByText(system).first()).toBeVisible();
+  });
+
+  test.afterEach(async () => {
+    if (system) {
+      await TestdataApi.removeSystem(system);
+    }
+  });
 });


### PR DESCRIPTION
- [x] Ran tests multiple times (yarn run env:AT22/TT02 --workers=4 --repeat-each=10) without failing.